### PR TITLE
fix(deps): patch websocket-driver (CRITICAL) + resolve remaining postcss (#12/#2)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19708,32 +19708,20 @@
       }
     },
     "node_modules/resolve-url-loader": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-4.0.0.tgz",
-      "integrity": "sha512-05VEMczVREcbtT7Bz+C+96eUO5HDNvdthIiMB34t7FcF8ehcu4wC0sSgPUubs3XW2Q3CNLJk/BJrCU9wVRymiA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
+      "integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "adjust-sourcemap-loader": "^4.0.0",
         "convert-source-map": "^1.7.0",
         "loader-utils": "^2.0.0",
-        "postcss": "^7.0.35",
+        "postcss": "^8.2.14",
         "source-map": "0.6.1"
       },
       "engines": {
-        "node": ">=8.9"
-      },
-      "peerDependencies": {
-        "rework": "1.0.1",
-        "rework-visit": "1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rework": {
-          "optional": true
-        },
-        "rework-visit": {
-          "optional": true
-        }
+        "node": ">=12"
       }
     },
     "node_modules/resolve-url-loader/node_modules/convert-source-map": {
@@ -19742,31 +19730,6 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/resolve-url-loader/node_modules/picocolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/resolve-url-loader/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
     },
     "node_modules/resolve-url-loader/node_modules/source-map": {
       "version": "0.6.1",
@@ -22502,9 +22465,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,8 +41,9 @@
     "http-proxy-middleware": "2.0.10",
     "launch-editor": "2.14.1",
     "postcss": "8.5.10",
-    "resolve-url-loader": { "postcss": "7.0.39" },
-    "@babel/core": "7.29.6"
+    "resolve-url-loader": "5.0.0",
+    "@babel/core": "7.29.6",
+    "websocket-driver": "0.7.5"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Follow-up to #39.

- **websocket-driver → 0.7.5** — fixes the newly-surfaced **CRITICAL** alert #52 (message corruption via protocol length headers). Dev/build tooling (sockjs → webpack-dev-server chain), not in the production bundle.
- **resolve-url-loader → 5.0.0** — pulls `postcss ^8`, fully resolving the last `postcss < 8.5.10` instance (#12) and #2 at the source. The project uses **no SASS**, so resolve-url-loader v4→v5 is inert at build time.

**Verified:** full production `docker build` succeeds on node 18; `postcss` now resolves to a single `8.5.10` across the tree; deferred dev-only deps (webpack-dev-server, serialize-javascript, uuid) unchanged. Only `package.json` + `package-lock.json` change.