### PR TITLE
fix(security): remediate RCE, missing-auth and SSRF advisories (backend-only)

### DIFF
--- a/backend/auth_middleware.py
+++ b/backend/auth_middleware.py
@@ -1,4 +1,4 @@
-from fastapi import HTTPException, status
+from fastapi import HTTPException, status, Header
 from typing import Optional, Dict, Any
 from jose import jwt
 import logging
@@ -91,6 +91,18 @@ async def get_current_user_from_token(authorization: Optional[str] = None) -> Op
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Authentication failed"
         )
+
+async def require_authenticated_user(authorization: Optional[str] = Header(None)) -> Dict[str, Any]:
+    """FastAPI dependency: require a valid operator JWT, else 401.
+
+    Reads the Authorization header itself, so it can be attached at router or
+    route level to gate operator/UI endpoints that must not be public:
+        APIRouter(..., dependencies=[Depends(require_authenticated_user)])
+        @router.get(..., dependencies=[Depends(require_authenticated_user)])
+    Any authenticated user passes (no fine-grained RBAC here) — this restores the
+    pre-existing "logged-in users only" expectation without changing role access.
+    """
+    return await get_current_user_from_token(authorization)
 
 async def get_current_user_from_token_no_exception(authorization: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """

--- a/backend/routers/agent.py
+++ b/backend/routers/agent.py
@@ -251,7 +251,7 @@ def calculate_agent_health(status, last_seen):
         return "offline"
 
 @router.get("", summary="Get All Agents", response_description="List of all agents")
-async def get_agents(pool_id: Optional[int] = None, authorization: str = Header(None)):
+async def get_agents(pool_id: Optional[int] = None, authorization: str = Header(None), x_api_key: Optional[str] = Header(None)):
     """
     # Get All Agents
     
@@ -305,9 +305,17 @@ async def get_agents(pool_id: Optional[int] = None, authorization: str = Header(
     """
     # SECURITY (GHSA-3p5c-m5m4-mjpx): the agent inventory (names, hostnames, IPs,
     # pools, OS) is operator data and was previously served unauthenticated — it is
-    # also the read-back channel used in the RCE exfil PoC. Require a valid JWT.
-    # Raised before the try so the 401 is not swallowed by the generic handler.
-    current_user = await get_current_user_from_token(authorization)
+    # also the read-back channel used in the RCE exfil PoC. Require EITHER a valid
+    # operator JWT OR a valid agent X-API-Key: deployed agents poll this endpoint
+    # (with their key, not a JWT) to read their own applied_config_version and avoid
+    # re-applying config on restart, so a JWT-only gate would break them. Checked
+    # before the try so the 401 is not swallowed by the generic handler.
+    if authorization:
+        current_user = await get_current_user_from_token(authorization)  # raises 401 on invalid JWT
+    else:
+        from auth_middleware import validate_agent_api_key
+        if not await validate_agent_api_key(x_api_key):
+            raise HTTPException(status_code=401, detail="Authentication required")
     try:
         conn = await get_database_connection()
 
@@ -768,6 +776,14 @@ async def generate_uninstall_script(platform: str, authorization: str = Header(N
     sudo ./uninstall-agent.sh
     ```
     """
+    # SECURITY (GHSA-3p5c-m5m4-mjpx): require authentication (operator JWT or agent
+    # key), consistent with generate-install-script. The uninstall script itself is
+    # generic (no secrets/topology), but an agent-management endpoint should not be
+    # anonymously reachable. Checked before the try so the 401 is not swallowed.
+    if authorization:
+        await get_current_user_from_token(authorization)
+    elif not await validate_agent_api_key(x_api_key):
+        raise HTTPException(status_code=401, detail="Authentication required")
     try:
         # Normalize platform to a canonical key (always 'linux' or 'macos').
         # macOS agents register with platform 'darwin' (from `uname -s`), so the
@@ -1103,6 +1119,8 @@ async def agent_config_applied_notification(agent_name: str, notification_data: 
         await close_database_connection(conn)
         return {"status": "ok", "message": "Config applied notification received"}
         
+    except HTTPException:
+        raise  # let auth 401/403 propagate (do not turn it into a 200 error body)
     except Exception as e:
         logger.error(f"Failed to process config applied notification from agent '{agent_name}': {e}")
         return {"status": "error", "message": str(e)}
@@ -1198,6 +1216,8 @@ async def agent_config_validation_failed(agent_name: str, notification_data: dic
         
         return {"status": "ok", "message": "Validation error notification received"}
         
+    except HTTPException:
+        raise  # let auth 401/403 propagate (do not turn it into a 200 error body)
     except Exception as e:
         logger.error(f"Failed to process validation error notification from agent '{agent_name}': {e}")
         return {"status": "error", "message": str(e)}
@@ -1487,6 +1507,8 @@ async def agent_config_sync(agent_name: str, sync_data: dict, x_api_key: Optiona
         logger.info(f"CONFIG SYNC: Agent '{agent_name}' synced {len(active_backends)} backends, {len(active_frontends)} frontends, {len(active_servers)} servers with database")
         return {"status": "ok", "message": f"Config synced - {len(active_backends)} backends, {len(active_frontends)} frontends, {len(active_servers)} servers processed"}
         
+    except HTTPException:
+        raise  # let auth 401/403 propagate (do not turn it into a 200 error body)
     except Exception as e:
         logger.error(f"Failed to process config sync from agent '{agent_name}': {e}")
         return {"status": "error", "message": str(e)}

--- a/backend/routers/agent.py
+++ b/backend/routers/agent.py
@@ -303,9 +303,14 @@ async def get_agents(pool_id: Optional[int] = None, authorization: str = Header(
     - **haproxy_status**: Status of HAProxy service on agent's server
     - **last_seen**: Last heartbeat timestamp
     """
+    # SECURITY (GHSA-3p5c-m5m4-mjpx): the agent inventory (names, hostnames, IPs,
+    # pools, OS) is operator data and was previously served unauthenticated — it is
+    # also the read-back channel used in the RCE exfil PoC. Require a valid JWT.
+    # Raised before the try so the 401 is not swallowed by the generic handler.
+    current_user = await get_current_user_from_token(authorization)
     try:
         conn = await get_database_connection()
-        
+
         try:
             if pool_id:
                 agents = await conn.fetch("""
@@ -958,14 +963,24 @@ def _extract_agent_ip(heartbeat_data: AgentHeartbeat) -> Optional[str]:
     return None
 
 @router.post("/{agent_id}/heartbeat")
-async def agent_heartbeat(agent_id: int, heartbeat_data: AgentHeartbeat):
+async def agent_heartbeat(agent_id: int, heartbeat_data: AgentHeartbeat, x_api_key: Optional[str] = Header(None)):
     """Receive agent heartbeat and update status."""
+    # Agent authentication is MANDATORY (GHSA-3p5c-m5m4-mjpx). This legacy by-ID
+    # heartbeat previously had NO auth, allowing unauthenticated state spoofing of
+    # any agent row. Deployed agents use the by-name heartbeat; a valid global
+    # agent token is now required here too. NOTE: raised BEFORE the try below so
+    # the 401 is not swallowed by the generic `except Exception` handler.
+    from auth_middleware import validate_agent_api_key
+    agent_auth = await validate_agent_api_key(x_api_key)
+    if not agent_auth:
+        logger.warning(f"Missing/invalid API key on by-id heartbeat for agent ID {agent_id}")
+        raise HTTPException(status_code=401, detail="Authentication required")
     try:
         conn = await get_database_connection()
-        
+
         await conn.execute("""
-            UPDATE agents 
-            SET status = 'online', 
+            UPDATE agents
+            SET status = 'online',
                 last_seen = CURRENT_TIMESTAMP,
                 hostname = COALESCE($2, hostname),
                 haproxy_status = COALESCE($3, haproxy_status),
@@ -1532,20 +1547,24 @@ async def agent_heartbeat_by_name(
         logger.error(f"Unexpected error processing heartbeat: {e}")
         raise HTTPException(status_code=500, detail="Internal server error")
     
+    # Agent authentication is MANDATORY (GHSA-3p5c-m5m4-mjpx). A valid global agent
+    # token is required to heartbeat OR auto-register. Deployed agents always send
+    # X-API-Key; an absent/invalid key is an unauthenticated caller. This is done
+    # OUTSIDE the processing try below (whose generic `except Exception` would
+    # otherwise convert the 401 into a 500), and before opening a DB connection
+    # (validate_agent_api_key(None) needs no DB). Closes keyless heartbeat spoofing
+    # and keyless rogue-agent auto-registration (the `elif not agent` keyless path
+    # below is now unreachable, since agent_auth is guaranteed truthy past here).
+    from auth_middleware import validate_agent_api_key
+    agent_auth = await validate_agent_api_key(x_api_key)
+    if not agent_auth:
+        logger.warning(f"Missing/invalid API key on heartbeat for agent '{heartbeat_data.name}'")
+        raise HTTPException(status_code=401, detail="Authentication required")
+
     # Continue with normal heartbeat processing
     try:
-        # Validate agent API key for security
-        from auth_middleware import validate_agent_api_key
-        agent_auth = await validate_agent_api_key(x_api_key)
-        
         conn = await get_database_connection()
         agent_name = heartbeat_data.name
-
-        # If API key provided, validate it exists but allow placeholder agent updates
-        if x_api_key and not agent_auth:
-            await close_database_connection(conn)
-            logger.warning(f"Invalid API key provided by agent '{agent_name}'")
-            raise HTTPException(status_code=401, detail="Invalid API key")
 
         agent = await conn.fetchrow("SELECT id, pool_id, api_key FROM agents WHERE name = $1", agent_name)
         
@@ -1955,9 +1974,19 @@ async def agent_heartbeat_by_name(
 @router.get("/{agent_name}/config")
 async def get_agent_config(agent_name: str, x_api_key: Optional[str] = Header(None)):
     """Get HAProxy configuration for specific agent"""
+    # Validate agent API key — MANDATORY (GHSA-3p5c-m5m4-mjpx). Checked BEFORE any
+    # DB work and before the existence check, so an unauthenticated caller learns
+    # neither the full haproxy.cfg nor whether the agent exists. Raised before the
+    # try so it is not swallowed by the generic handler; validate_agent_api_key(None)
+    # returns None without touching the DB.
+    from auth_middleware import validate_agent_api_key
+    agent_auth = await validate_agent_api_key(x_api_key)
+    if not agent_auth:
+        logger.warning(f"Missing/invalid API key for agent '{agent_name}' config fetch")
+        raise HTTPException(status_code=401, detail="Authentication required")
     try:
         conn = await get_database_connection()
-        
+
         # Get agent info first to check pool
         # CRITICAL: Include cluster's haproxy_bin_path, haproxy_config_path, stats_socket_path
         # These are needed for dynamic validation - cluster admin can change paths without reinstalling agent
@@ -1969,30 +1998,19 @@ async def get_agent_config(agent_name: str, x_api_key: Optional[str] = Header(No
             LEFT JOIN haproxy_clusters hc ON hc.pool_id = a.pool_id
             WHERE a.name = $1
         """, agent_name)
-        
+
         if not agent_info:
             await close_database_connection(conn)
             raise HTTPException(status_code=404, detail=f"Agent '{agent_name}' not found")
-        
-        # Validate agent API key
-        # API key is global - can be used for multiple agents
-        if x_api_key:
-            from auth_middleware import validate_agent_api_key
-            agent_auth = await validate_agent_api_key(x_api_key)
-            
-            if not agent_auth:
-                await close_database_connection(conn)
-                logger.warning(f"Invalid API key provided for agent '{agent_name}' config fetch")
-                raise HTTPException(status_code=401, detail="Invalid API key")
-            
-            # Log which agent's API key was used (for audit trail)
-            if agent_auth['name'] == agent_name:
-                logger.info(f"Agent '{agent_name}' fetching config using its own API key")
-            else:
-                logger.info(f"Agent '{agent_name}' fetching config using API key from agent '{agent_auth['name']}'")
-            
-            logger.debug(f"Config fetch authorized for agent '{agent_name}'")
-        
+
+        # Log which agent's API key was used (for audit trail)
+        if agent_auth['name'] == agent_name:
+            logger.info(f"Agent '{agent_name}' fetching config using its own API key")
+        else:
+            logger.info(f"Agent '{agent_name}' fetching config using API key from agent '{agent_auth['name']}'")
+
+        logger.debug(f"Config fetch authorized for agent '{agent_name}'")
+
         if not agent_info['enabled']:
             await close_database_connection(conn)
             return {
@@ -2083,9 +2101,18 @@ async def get_agent_config(agent_name: str, x_api_key: Optional[str] = Header(No
 @router.get("/{agent_name}/ssl-certificates")
 async def get_agent_ssl_certificates(agent_name: str, since: Optional[str] = None, x_api_key: Optional[str] = Header(None)):
     """Get SSL certificates for specific agent's cluster"""
+    # Validate agent API key — MANDATORY (GHSA-3p5c-m5m4-mjpx). This response
+    # returns SSL private_key_content, so authentication is checked BEFORE any DB
+    # work and before the existence check. Raised before the try so the 401 is not
+    # swallowed; validate_agent_api_key(None) returns None without a DB hit.
+    from auth_middleware import validate_agent_api_key
+    agent_auth = await validate_agent_api_key(x_api_key)
+    if not agent_auth:
+        logger.warning(f"Missing/invalid API key for agent '{agent_name}' SSL certificates")
+        raise HTTPException(status_code=401, detail="Authentication required")
     try:
         conn = await get_database_connection()
-        
+
         # Get agent and cluster info first
         agent_info = await conn.fetchrow("""
             SELECT a.id, a.name, a.pool_id, hc.id as cluster_id, hc.name as cluster_name,
@@ -2094,29 +2121,18 @@ async def get_agent_ssl_certificates(agent_name: str, since: Optional[str] = Non
             LEFT JOIN haproxy_clusters hc ON hc.pool_id = a.pool_id
             WHERE a.name = $1
         """, agent_name)
-        
+
         if not agent_info:
             await close_database_connection(conn)
             raise HTTPException(status_code=404, detail=f"Agent '{agent_name}' not found")
-        
-        # Validate agent API key
-        # API key is global - can be used for multiple agents
-        if x_api_key:
-            from auth_middleware import validate_agent_api_key
-            agent_auth = await validate_agent_api_key(x_api_key)
-            
-            if not agent_auth:
-                await close_database_connection(conn)
-                logger.warning(f"Invalid API key provided for agent '{agent_name}' SSL certificates")
-                raise HTTPException(status_code=401, detail="Invalid API key")
-            
-            # Log which agent's API key was used (for audit trail)
-            if agent_auth['name'] == agent_name:
-                logger.info(f"Agent '{agent_name}' fetching SSL certificates using its own API key")
-            else:
-                logger.info(f"Agent '{agent_name}' fetching SSL certificates using API key from agent '{agent_auth['name']}'")
-            
-            logger.debug(f"SSL fetch authorized for agent '{agent_name}'")
+
+        # Log which agent's API key was used (for audit trail)
+        if agent_auth['name'] == agent_name:
+            logger.info(f"Agent '{agent_name}' fetching SSL certificates using its own API key")
+        else:
+            logger.info(f"Agent '{agent_name}' fetching SSL certificates using API key from agent '{agent_auth['name']}'")
+
+        logger.debug(f"SSL fetch authorized for agent '{agent_name}'")
         
         if not agent_info['enabled']:
             await close_database_connection(conn)
@@ -2440,16 +2456,24 @@ async def get_latest_script_version(platform: str = "macos"):
 @router.get("/{agent_name}/upgrade-status")
 async def get_agent_upgrade_status(agent_name: str, x_api_key: Optional[str] = Header(None)):
     """Get agent upgrade status - used by agents to check if they should upgrade"""
+    # Validate agent API key — MANDATORY (GHSA-3p5c-m5m4-mjpx). Checked before any
+    # DB work; deployed agents always send X-API-Key. Raised before the try so the
+    # 401 is not swallowed; validate_agent_api_key(None) returns None without a DB hit.
+    from auth_middleware import validate_agent_api_key
+    agent_auth = await validate_agent_api_key(x_api_key)
+    if not agent_auth:
+        logger.warning(f"Missing/invalid API key for agent '{agent_name}' upgrade status")
+        raise HTTPException(status_code=401, detail="Authentication required")
     try:
         conn = await get_database_connection()
-        
+
         # Check if agent has upgrade pending (include platform and pool for validation)
         agent = await conn.fetchrow("""
             SELECT status, version as current_version, platform, pool_id
-            FROM agents 
+            FROM agents
             WHERE name = $1
         """, agent_name)
-        
+
         if not agent:
             await close_database_connection(conn)
             return {
@@ -2457,26 +2481,15 @@ async def get_agent_upgrade_status(agent_name: str, x_api_key: Optional[str] = H
                 "target_version": "",
                 "message": "Agent not found"
             }
-        
-        # Validate agent API key
-        # API key is global - can be used for multiple agents
-        if x_api_key:
-            from auth_middleware import validate_agent_api_key
-            agent_auth = await validate_agent_api_key(x_api_key)
-            
-            if not agent_auth:
-                await close_database_connection(conn)
-                logger.warning(f"Invalid API key provided for agent '{agent_name}' upgrade status")
-                raise HTTPException(status_code=401, detail="Invalid API key")
-            
-            # Log which agent's API key was used (for audit trail)
-            if agent_auth['name'] == agent_name:
-                logger.debug(f"Agent '{agent_name}' checking upgrade status using its own API key")
-            else:
-                logger.info(f"Agent '{agent_name}' checking upgrade status using API key from agent '{agent_auth['name']}'")
-            
-            logger.debug(f"Upgrade status check authorized for agent '{agent_name}'")
-        
+
+        # Log which agent's API key was used (for audit trail)
+        if agent_auth['name'] == agent_name:
+            logger.debug(f"Agent '{agent_name}' checking upgrade status using its own API key")
+        else:
+            logger.info(f"Agent '{agent_name}' checking upgrade status using API key from agent '{agent_auth['name']}'")
+
+        logger.debug(f"Upgrade status check authorized for agent '{agent_name}'")
+
         await close_database_connection(conn)
         
         # Agent should upgrade if status is 'upgrading'
@@ -2910,7 +2923,17 @@ async def get_agent_script_template(platform: str, authorization: str = Header(N
     """Get the latest script template for specified platform from database"""
     try:
         current_user = await get_current_user_from_token(authorization)
-        
+
+        # SECURITY (GHSA-7rhv-c5pc-69r8): the raw install/upgrade script is a
+        # version-management surface. Gate reads with agents.version too, matching
+        # the write path above (operator/security_admin/super_admin retain access).
+        has_permission = await check_user_permission(current_user["id"], "agents", "version")
+        if not has_permission:
+            raise HTTPException(
+                status_code=403,
+                detail="Insufficient permissions: agents.version required"
+            )
+
         conn = await get_database_connection()
         
         # Get latest script template for platform
@@ -2961,7 +2984,19 @@ async def save_agent_script_template(platform: str, template_data: dict, authori
     """Save updated script template to database using shared helper function"""
     try:
         current_user = await get_current_user_from_token(authorization)
-        
+
+        # SECURITY (GHSA-7rhv-c5pc-69r8): agent script templates become the
+        # install/self-upgrade script executed as root on HAProxy nodes. A poisoned
+        # template is RCE. Authentication alone is NOT enough — require the same
+        # agents.version permission as POST /versions; otherwise any JWT holder
+        # (including viewer) could overwrite the active script.
+        has_permission = await check_user_permission(current_user["id"], "agents", "version")
+        if not has_permission:
+            raise HTTPException(
+                status_code=403,
+                detail="Insufficient permissions: agents.version required"
+            )
+
         script_content = template_data.get('script_content', '')
         version = template_data.get('version', '')
         

--- a/backend/routers/config.py
+++ b/backend/routers/config.py
@@ -3,7 +3,7 @@ Configuration Management and Validation API
 Provides endpoints for HAProxy configuration validation, templates, and optimization
 """
 
-from fastapi import APIRouter, HTTPException, Header, Request
+from fastapi import APIRouter, HTTPException, Header, Request, Depends
 from pydantic import BaseModel
 from typing import Dict, List, Any, Optional
 import logging
@@ -18,7 +18,7 @@ from utils.config_templates import (
 )
 from utils.haproxy_config_parser import parse_haproxy_config
 from utils.logging_config import log_with_correlation, PerformanceLogger
-from auth_middleware import get_current_user_from_token
+from auth_middleware import get_current_user_from_token, require_authenticated_user
 from database.connection import get_database_connection, close_database_connection
 
 router = APIRouter(prefix="/api/config", tags=["Configuration Management"])
@@ -62,7 +62,7 @@ class ConfigOptimizationRequest(BaseModel):
     optimization_level: str = "balanced"  # conservative, balanced, aggressive
     target_environment: str = "production"  # development, staging, production
 
-@router.post("/validate")
+@router.post("/validate", dependencies=[Depends(require_authenticated_user)])  # SECURITY (GHSA-3p5c): was optional-auth; runs HAProxy validator on caller input
 async def validate_configuration(
     request: ConfigValidationRequest,
     current_user: dict = None,
@@ -203,7 +203,7 @@ async def get_template_details(template_id: str):
         )
         raise HTTPException(status_code=500, detail=f"Failed to get template: {str(e)}")
 
-@router.post("/templates/{template_id}/generate")
+@router.post("/templates/{template_id}/generate", dependencies=[Depends(require_authenticated_user)])  # SECURITY (GHSA-3p5c): was optional-auth
 async def generate_configuration(
     template_id: str,
     request: TemplateGenerationRequest,
@@ -271,7 +271,7 @@ async def generate_configuration(
                 detail=f"Configuration generation failed: {str(e)}"
             )
 
-@router.post("/optimize")
+@router.post("/optimize", dependencies=[Depends(require_authenticated_user)])  # SECURITY (GHSA-3p5c): was optional-auth
 async def optimize_configuration(
     request: ConfigOptimizationRequest,
     current_user: dict = None,

--- a/backend/routers/configuration.py
+++ b/backend/routers/configuration.py
@@ -201,13 +201,15 @@ async def get_pending_config_requests(agent_name: str, x_api_key: Optional[str] 
     Called during heartbeat.
     """
     try:
-        # Validate agent API key
+        # Validate agent API key — MANDATORY (GHSA-3p5c-m5m4-mjpx). Deployed agents
+        # always send X-API-Key; an absent/invalid key is unauthenticated. This
+        # endpoint also mutates state (marks requests 'processing'), so a keyless
+        # caller could otherwise starve the real agent.
         agent_auth = await validate_agent_api_key(x_api_key)
-        
-        if x_api_key and not agent_auth:
-            logger.warning(f"Invalid API key provided by agent '{agent_name}' for pending requests")
-            raise HTTPException(status_code=401, detail="Invalid API key")
-        
+        if not agent_auth:
+            logger.warning(f"Missing/invalid API key from '{agent_name}' for pending requests")
+            raise HTTPException(status_code=401, detail="Authentication required")
+
         conn = await get_database_connection()
         
         # Get pending requests

--- a/backend/routers/dashboard.py
+++ b/backend/routers/dashboard.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, HTTPException, Header
+from fastapi import APIRouter, HTTPException, Header, Depends
+from auth_middleware import require_authenticated_user
 from typing import Optional
 from datetime import datetime
 import logging
@@ -11,7 +12,7 @@ from agent_notifications import get_cluster_agents_status
 router = APIRouter(prefix="/api", tags=["dashboard", "pools"])
 logger = logging.getLogger(__name__)
 
-@router.get("/dashboard/overview")
+@router.get("/dashboard/overview", dependencies=[Depends(require_authenticated_user)])  # SECURITY (GHSA-3p5c): leaked cluster/pool/agent stats, names, health & alerts anonymously (auth was optional)
 async def get_dashboard_overview(cluster_id: Optional[int] = None, authorization: str = Header(None)):
     """Get dashboard overview with comprehensive statistics, optionally filtered by cluster"""
     try:
@@ -238,7 +239,7 @@ async def get_dashboard_overview(cluster_id: Optional[int] = None, authorization
         logger.error(f"Error fetching dashboard overview: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
-@router.get("/dashboard/stats")
+@router.get("/dashboard/stats", dependencies=[Depends(require_authenticated_user)])  # SECURITY (GHSA-3p5c): aggregate cluster/agent counts
 async def get_dashboard_stats():
     """Get dashboard statistics"""
     try:
@@ -279,7 +280,7 @@ async def get_dashboard_stats():
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@router.get("/pools")
+@router.get("/pools", dependencies=[Depends(require_authenticated_user)])  # SECURITY (GHSA-3p5c): pool names/env/counts
 async def get_pools():
     """Get all HAProxy cluster pools"""
     try:
@@ -350,7 +351,7 @@ async def get_pools():
         logger.error(f"Error fetching pools: {e}")
         return {"pools": []}
 
-@router.get("/haproxy-cluster-pools")
+@router.get("/haproxy-cluster-pools", dependencies=[Depends(require_authenticated_user)])  # SECURITY (GHSA-3p5c)
 async def get_haproxy_cluster_pools():
     """Get all HAProxy cluster pools (legacy endpoint)"""
     # Just call the main pools endpoint
@@ -474,7 +475,7 @@ async def update_pool(pool_id: int, pool: PoolUpdate, authorization: str = Heade
         logger.error(f"Failed to update pool: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to update pool: {str(e)}")
 
-@router.get("/haproxy-cluster-pools/{pool_id}/agents")
+@router.get("/haproxy-cluster-pools/{pool_id}/agents", dependencies=[Depends(require_authenticated_user)])  # SECURITY (GHSA-3p5c): full agent inventory — same class as GET /api/agents
 async def get_pool_agents(pool_id: int):
     """Get all agents for a specific pool"""
     try:
@@ -561,7 +562,7 @@ async def get_pool_agents(pool_id: int):
         logger.error(f"Error fetching pool agents: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to fetch pool agents: {str(e)}")
 
-@router.get("/haproxy/stats")
+@router.get("/haproxy/stats", dependencies=[Depends(require_authenticated_user)])  # SECURITY (GHSA-3p5c)
 async def get_haproxy_stats(cluster_id: Optional[int] = None):
     """Get HAProxy statistics"""
     try:

--- a/backend/routers/dashboard_stats.py
+++ b/backend/routers/dashboard_stats.py
@@ -3,13 +3,22 @@ Dashboard Stats Router
 API endpoints for HAProxy statistics dashboard
 """
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Depends
 from typing import Optional, List
 import logging
 
 from services.dashboard_stats_service import dashboard_stats_service
+from auth_middleware import require_authenticated_user
 
-router = APIRouter(prefix="/api/dashboard-stats", tags=["dashboard-stats"])
+# SECURITY (GHSA-3p5c-m5m4-mjpx): this entire router (traffic metrics, backend
+# health, cluster topology, agent status) was mounted without authentication.
+# Require a valid JWT on every route. The frontend Dashboard already sends the
+# operator JWT on these calls, so this is transparent to the UI.
+router = APIRouter(
+    prefix="/api/dashboard-stats",
+    tags=["dashboard-stats"],
+    dependencies=[Depends(require_authenticated_user)],
+)
 logger = logging.getLogger(__name__)
 
 

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -330,7 +330,7 @@ async def clusters_health():
         logger.error(f"Cluster health check failed: {e}")
         raise HTTPException(status_code=500, detail=f"Cluster health check failed: {str(e)}")
 
-@router.get("/errors")
+@router.get("/errors", dependencies=[Depends(require_authenticated_user)])  # SECURITY (GHSA-3p5c): app error metrics, sibling of /deep,/agents,/clusters
 async def error_statistics():
     """Get application error statistics and metrics"""
     try:

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -3,8 +3,9 @@ Production-Ready Health Check and Monitoring Endpoints
 Provides comprehensive system health monitoring for Kubernetes and production environments
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import JSONResponse
+from auth_middleware import require_authenticated_user
 import logging
 import asyncio
 import time
@@ -74,7 +75,7 @@ async def readiness_probe():
         logger.error(f"Readiness probe failed: {e}")
         raise HTTPException(status_code=503, detail=f"Not ready: {str(e)}")
 
-@router.get("/deep")
+@router.get("/deep", dependencies=[Depends(require_authenticated_user)])  # SECURITY (GHSA-3p5c): leaks host CPU/mem/disk, DB/redis/python versions, PID
 async def deep_health_check():
     """Comprehensive health check with detailed system information"""
     global _health_cache
@@ -197,7 +198,7 @@ async def deep_health_check():
         
         raise HTTPException(status_code=503, detail=error_response)
 
-@router.get("/agents")
+@router.get("/agents", dependencies=[Depends(require_authenticated_user)])  # SECURITY (GHSA-3p5c): leaks agent names/hostnames
 async def agents_health():
     """Monitor agent connectivity and health status"""
     try:
@@ -261,7 +262,7 @@ async def agents_health():
         logger.error(f"Agent health check failed: {e}")
         raise HTTPException(status_code=500, detail=f"Agent health check failed: {str(e)}")
 
-@router.get("/clusters")
+@router.get("/clusters", dependencies=[Depends(require_authenticated_user)])  # SECURITY (GHSA-3p5c): leaks cluster names, HAProxy versions, pending counts
 async def clusters_health():
     """Monitor HAProxy cluster health and configuration status"""
     try:

--- a/backend/routers/letsencrypt.py
+++ b/backend/routers/letsencrypt.py
@@ -87,6 +87,32 @@ class AccountCreate(BaseModel):
             raise ValueError("eab_hmac_key is not valid base64; copy it exactly from your CA account.")
         return v
 
+    @field_validator('directory_url')
+    @classmethod
+    def _validate_directory_url(cls, v):
+        # SECURITY (GHSA-3vh4-gvxx-wm2p): reject non-https URLs and literal
+        # non-public IP hosts at the API boundary. The full DNS-based SSRF check
+        # runs at fetch time (acme_service.get_directory -> ssrf_guard).
+        if not v:
+            return v
+        from urllib.parse import urlparse
+        import ipaddress
+        from utils.ssrf_guard import is_public_ip
+        parsed = urlparse(v.strip())
+        if parsed.scheme.lower() != 'https':
+            raise ValueError("directory_url must be an https URL")
+        host = parsed.hostname
+        if not host:
+            raise ValueError("directory_url has no host")
+        try:
+            ipaddress.ip_address(host)
+            is_ip_literal = True
+        except ValueError:
+            is_ip_literal = False
+        if is_ip_literal and not is_public_ip(host):
+            raise ValueError("directory_url must not point to a private/loopback IP address")
+        return v
+
     @model_validator(mode='after')
     def _require_provider_for_dns01(self):
         if self.challenge_type == 'dns-01' and not (self.dns_provider or '').strip():

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -104,16 +104,40 @@ async def test_acme_connection(authorization: str = Header(None), directory_url:
         finally:
             await close_database_connection(conn)
 
+    # SECURITY (GHSA-3vh4-gvxx-wm2p): validate the URL before any outbound request
+    # (https-only; block loopback/RFC1918/link-local/cloud-metadata after DNS),
+    # pin the connector to IPv4, and never follow redirects. Also do NOT reflect
+    # arbitrary upstream JSON keys back to the caller — that was an information-
+    # disclosure oracle. Only report presence of the FIXED, known ACME directory
+    # field names (never attacker-controlled data).
+    from utils.ssrf_guard import assert_public_url, safe_connector, SSRFValidationError
+
+    directory_url = str(directory_url)
+    try:
+        await assert_public_url(directory_url)
+    except SSRFValidationError as e:
+        return {"success": False, "error": f"Refused to fetch directory URL: {e}"}
+
+    _KNOWN_ACME_FIELDS = ["newNonce", "newAccount", "newOrder", "newAuthz", "revokeCert", "keyChange"]
     try:
         import aiohttp
-        async with aiohttp.ClientSession() as session:
-            async with session.get(str(directory_url), timeout=aiohttp.ClientTimeout(total=10)) as resp:
+        async with aiohttp.ClientSession(connector=safe_connector()) as session:
+            async with session.get(
+                directory_url,
+                timeout=aiohttp.ClientTimeout(total=10),
+                allow_redirects=False,
+            ) as resp:
                 if resp.status == 200:
-                    data = await resp.json()
+                    data = await resp.json(content_type=None)
+                    if not isinstance(data, dict):
+                        return {"success": False, "error": "Directory URL did not return a JSON object"}
+                    present = [k for k in _KNOWN_ACME_FIELDS if k in data]
+                    if not present:
+                        return {"success": False, "error": "Response is not a valid ACME directory"}
                     return {
                         "success": True,
-                        "directory": str(directory_url),
-                        "endpoints": list(data.keys()) if isinstance(data, dict) else []
+                        "directory": directory_url,
+                        "endpoints": present,
                     }
                 else:
                     return {"success": False, "error": f"HTTP {resp.status} from directory URL"}

--- a/backend/routers/ssl.py
+++ b/backend/routers/ssl.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 
 # Import database and models
 from database.connection import get_database_connection, close_database_connection
-from auth_middleware import get_current_user_from_token
+from auth_middleware import get_current_user_from_token, require_authenticated_user
 from models.ssl import SSLCertificate, SSLCertificateCreate, SSLCertificateUpdate, SSLCertificateResponse
 from utils.ssl_parser import parse_ssl_certificate, validate_private_key, validate_certificate_chain, format_certificate_info
 from utils.activity_log import log_user_activity
@@ -825,7 +825,8 @@ async def get_ssl_certificate(cert_id: int, authorization: str = Header(None)):
         logger.error(f"Error getting SSL certificate: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
-@router.get("/certificates/{cert_id}/config-versions")
+@router.get("/certificates/{cert_id}/config-versions",
+            dependencies=[Depends(require_authenticated_user)])  # SECURITY (GHSA-3p5c): was unauthenticated
 async def get_ssl_certificate_config_versions(cert_id: int):
     """Get config version history for specific SSL certificate"""
     try:

--- a/backend/routers/waf.py
+++ b/backend/routers/waf.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, HTTPException, Request, Header
+from fastapi import APIRouter, HTTPException, Request, Header, Depends
+from auth_middleware import require_authenticated_user
 from typing import Optional
 import logging
 import time
@@ -182,7 +183,8 @@ async def get_waf_stats(cluster_id: Optional[int] = None, authorization: str = H
         logger.error(f"Error fetching WAF stats: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
-@router.get("/rules", summary="Get WAF Rules", response_description="List of WAF rules")
+@router.get("/rules", summary="Get WAF Rules", response_description="List of WAF rules",
+            dependencies=[Depends(require_authenticated_user)])  # SECURITY (GHSA-3p5c): WAF rule definitions aid bypass crafting
 async def get_waf_rules(cluster_id: Optional[int] = None):
     """
     # Get WAF Rules

--- a/backend/services/acme_service.py
+++ b/backend/services/acme_service.py
@@ -69,8 +69,14 @@ class ACMEService:
             if cached.get('_fetched_at', 0) > time.time() - 3600:
                 return cached
 
-        async with aiohttp.ClientSession() as session:
-            async with session.get(directory_url, timeout=aiohttp.ClientTimeout(total=15)) as resp:
+        # SECURITY (GHSA-3vh4-gvxx-wm2p): directory_url can come from a stored
+        # account row; validate it (https + public IP, no redirects) before the
+        # server-side fetch so it cannot be pointed at internal/metadata targets.
+        from utils.ssrf_guard import assert_public_url, safe_connector
+        await assert_public_url(directory_url)
+
+        async with aiohttp.ClientSession(connector=safe_connector()) as session:
+            async with session.get(directory_url, timeout=aiohttp.ClientTimeout(total=15), allow_redirects=False) as resp:
                 if resp.status != 200:
                     raise Exception(f"Failed to fetch ACME directory: HTTP {resp.status}")
                 data = await resp.json()
@@ -187,13 +193,21 @@ class ACMEService:
 
         body = self._sign_jws(private_key, protected, payload)
 
-        async with aiohttp.ClientSession() as session:
+        # SECURITY (GHSA-3vh4-gvxx-wm2p): `url` is taken from the CA directory /
+        # order responses. The directory is already fetched from a validated
+        # public CA, but guard the follow-up POST target too (defence in depth)
+        # so a tampered/malicious directory cannot steer the request internally.
+        from utils.ssrf_guard import assert_public_url, safe_connector
+        await assert_public_url(url)
+
+        async with aiohttp.ClientSession(connector=safe_connector()) as session:
             for attempt in range(3):
                 async with session.post(
                     url,
                     json=body,
                     headers={"Content-Type": "application/jose+json"},
                     timeout=aiohttp.ClientTimeout(total=30),
+                    allow_redirects=False,
                 ) as resp:
                     if 'Replay-Nonce' in resp.headers:
                         self._nonce_by_dir[directory_url] = resp.headers['Replay-Nonce']

--- a/backend/services/acme_service.py
+++ b/backend/services/acme_service.py
@@ -96,8 +96,16 @@ class ACMEService:
         cached = self._nonce_by_dir.pop(directory_url, None)
         if cached:
             return cached
-        async with aiohttp.ClientSession() as session:
-            async with session.head(directory['newNonce']) as resp:
+        # SECURITY (GHSA-3vh4-gvxx-wm2p): newNonce is taken from the (attacker-
+        # influenceable) directory JSON and is fetched here BEFORE the guarded
+        # _signed_request POST, so it must be guarded too — otherwise a directory
+        # that returns an internal newNonce (and omits Replay-Nonce) is a live SSRF.
+        # https + public IP only, IPv4-pinned connector, no redirects, bounded timeout.
+        from utils.ssrf_guard import assert_public_url, safe_connector
+        nonce_url = directory['newNonce']
+        await assert_public_url(nonce_url)
+        async with aiohttp.ClientSession(connector=safe_connector()) as session:
+            async with session.head(nonce_url, timeout=aiohttp.ClientTimeout(total=15), allow_redirects=False) as resp:
                 return resp.headers['Replay-Nonce']
 
     def _generate_account_key(self) -> Tuple[str, dict]:

--- a/backend/tests/test_security_advisories_auth.py
+++ b/backend/tests/test_security_advisories_auth.py
@@ -122,6 +122,87 @@ def test_script_template_read_requires_auth(client):
     assert res.status_code in REJECT
 
 
+# --------------------------------------------------------------------------
+# GHSA-3p5c (round 2): sibling endpoints exposing the SAME class of data
+# (found during post-merge review — must also require a JWT)
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("path", [
+    "/api/haproxy-cluster-pools/1/agents",   # full agent inventory — same class as GET /api/agents
+    "/api/pools",
+    "/api/haproxy-cluster-pools",
+    "/api/dashboard/stats",
+    "/api/dashboard/overview",               # optional-auth pattern — leaked stats/names/alerts anonymously
+    "/api/haproxy/stats",
+    "/api/waf/rules",
+    "/api/health/errors",
+])
+def test_sibling_inventory_endpoints_require_jwt(client, path):
+    res = client.get(path)
+    assert res.status_code in REJECT, (
+        f"GHSA-3p5c (round 2) regression: {path} served without a JWT ({res.status_code}) — "
+        f"anonymous access to inventory/topology/WAF/error data"
+    )
+
+
+def test_pool_agents_no_anonymous_inventory_leak(client):
+    """The richest bypass: /api/haproxy-cluster-pools/{id}/agents must not leak inventory."""
+    res = client.get("/api/haproxy-cluster-pools/1/agents")
+    assert res.status_code in REJECT
+    if res.status_code == 200:
+        assert "ip_address" not in res.text and "hostname" not in res.text
+
+
+# --------------------------------------------------------------------------
+# GHSA-3p5c (round 2): agent webhooks must return 401 (not a 200 error body)
+# for anonymous callers — the auth raise must propagate, not be swallowed.
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("path", [
+    "/api/agents/some-agent/config-applied",
+    "/api/agents/some-agent/config-validation-failed",
+    "/api/agents/some-agent/config-sync",
+])
+def test_agent_webhooks_reject_anonymous_with_401(client, path):
+    res = client.post(path, json={})
+    assert res.status_code in REJECT, (
+        f"{path} returned {res.status_code} for an anonymous caller — the auth "
+        f"rejection must be a 401/403, not a swallowed 200 error body"
+    )
+    # Specifically must NOT be a 200 "status: error" body.
+    assert res.status_code != 200
+
+
+# --------------------------------------------------------------------------
+# GHSA-3p5c (round 2): GET /api/agents must accept EITHER a JWT OR an agent
+# X-API-Key. Anonymous (neither) is still rejected — agents send a key, so a
+# JWT-only gate would break them (verified end-to-end in the localtest smoke).
+# --------------------------------------------------------------------------
+
+def test_agents_inventory_still_rejects_fully_anonymous(client):
+    """No JWT and no X-API-Key -> 401 (the agent-key accept path needs a valid key)."""
+    res = client.get("/api/agents")
+    assert res.status_code in REJECT
+
+
+def test_generate_uninstall_script_requires_auth(client):
+    """Agent-management endpoint must not be anonymously reachable (JWT or agent key)."""
+    res = client.get("/api/agents/generate-uninstall-script/linux")
+    assert res.status_code in REJECT
+
+
+@pytest.mark.parametrize("path", [
+    "/api/config/validate",
+    "/api/config/optimize",
+    "/api/config/templates/default/generate",
+])
+def test_config_compute_endpoints_require_auth(client, path):
+    """Config compute endpoints (run a HAProxy validator on caller input) were
+    optional-auth; now require a JWT. The dependency rejects before body parsing."""
+    res = client.post(path, json={})
+    assert res.status_code in REJECT
+
+
 def test_script_template_write_enforces_agents_version_permission():
     """Static guarantee: the write handler checks agents.version (not just authN).
 

--- a/backend/tests/test_security_advisories_auth.py
+++ b/backend/tests/test_security_advisories_auth.py
@@ -1,0 +1,142 @@
+"""Regression tests for the 2026-07 security advisories.
+
+Covers:
+- GHSA-7rhv-c5pc-69r8 (CRITICAL RCE): agent script-template management must
+  require the agents.version permission, not merely authentication.
+- GHSA-3p5c-m5m4-mjpx (missing auth): agent data-plane endpoints must require a
+  valid X-API-Key, and operator/UI endpoints must require a JWT. An anonymous
+  caller must never get a 200 with sensitive data.
+
+These are behavioral assertions via FastAPI's TestClient. The auth checks were
+deliberately moved ahead of any DB access, so an unauthenticated request is
+rejected without needing a database — the same approach as the existing
+test_ssl_list_endpoint_auth.py. Accepted rejection statuses are 401/403/422
+(never 200-with-data).
+"""
+import re
+import os
+import pytest
+
+REJECT = (401, 403, 422)
+
+
+# --------------------------------------------------------------------------
+# GHSA-3p5c: agent data-plane endpoints must reject a missing X-API-Key
+# --------------------------------------------------------------------------
+
+def test_agent_config_requires_api_key(client):
+    """GET /api/agents/{name}/config leaked the full haproxy.cfg without a key."""
+    res = client.get("/api/agents/prod-haproxy-1/config")
+    assert res.status_code in REJECT, (
+        f"GHSA-3p5c regression: agent config served without X-API-Key ({res.status_code})"
+    )
+
+
+def test_agent_ssl_certificates_requires_api_key(client):
+    """GET /api/agents/{name}/ssl-certificates leaked SSL private keys without a key."""
+    res = client.get("/api/agents/prod-haproxy-1/ssl-certificates")
+    assert res.status_code in REJECT, (
+        f"GHSA-3p5c regression: SSL certs (private keys!) served without X-API-Key ({res.status_code})"
+    )
+    if res.status_code == 200:
+        assert "private_key_content" not in res.text
+
+
+def test_agent_upgrade_status_requires_api_key(client):
+    res = client.get("/api/agents/prod-haproxy-1/upgrade-status")
+    assert res.status_code in REJECT
+
+
+def test_agent_pending_requests_requires_api_key(client):
+    res = client.get("/api/configuration/agents/prod-haproxy-1/pending-requests")
+    assert res.status_code in REJECT
+
+
+def test_agent_heartbeat_by_name_requires_api_key(client):
+    res = client.post("/api/agents/heartbeat", json={"name": "rogue-poc"})
+    assert res.status_code in REJECT, (
+        f"GHSA-3p5c regression: keyless heartbeat/auto-register accepted ({res.status_code})"
+    )
+
+
+def test_agent_heartbeat_by_id_requires_api_key(client):
+    res = client.post("/api/agents/1/heartbeat", json={"name": "spoofed"})
+    assert res.status_code in REJECT, (
+        f"GHSA-3p5c regression: keyless by-id heartbeat state-spoof accepted ({res.status_code})"
+    )
+
+
+# --------------------------------------------------------------------------
+# GHSA-3p5c: operator/UI endpoints must reject a missing JWT
+# --------------------------------------------------------------------------
+
+def test_agents_inventory_requires_jwt(client):
+    """GET /api/agents (RCE read-back channel) was served without a JWT."""
+    res = client.get("/api/agents")
+    assert res.status_code in REJECT
+
+
+@pytest.mark.parametrize("path", ["/api/health/deep", "/api/health/agents", "/api/health/clusters"])
+def test_detailed_health_requires_jwt(client, path):
+    res = client.get(path)
+    assert res.status_code in REJECT, f"{path} served without a JWT ({res.status_code})"
+
+
+def test_simple_health_stays_public(client):
+    """The liveness probe endpoint (/api/health) must remain UNAUTHENTICATED.
+
+    It reports 200 when healthy and 503 when the DB is unreachable (as in this
+    no-DB test env); what matters for the k8s probe is that it is never gated
+    behind auth (401/403). We only added auth to /api/health/{deep,agents,clusters}.
+    """
+    res = client.get("/api/health")
+    assert res.status_code not in (401, 403), (
+        f"Regression: /api/health liveness probe now requires auth ({res.status_code}) — "
+        f"this breaks k8s liveness/readiness"
+    )
+
+
+def test_dashboard_stats_requires_jwt(client):
+    res = client.get("/api/dashboard-stats/stats?cluster_id=1")
+    assert res.status_code in REJECT
+
+
+def test_ssl_config_versions_requires_jwt(client):
+    res = client.get("/api/ssl/certificates/1/config-versions")
+    assert res.status_code in REJECT
+
+
+# --------------------------------------------------------------------------
+# GHSA-7rhv (CRITICAL RCE): script-template management
+# --------------------------------------------------------------------------
+
+def test_script_template_write_requires_auth(client):
+    """Anonymous POST must be rejected outright."""
+    res = client.post("/api/agents/script-templates/linux",
+                      json={"script_content": "#!/bin/bash\nid", "version": "9.9.9"})
+    assert res.status_code in REJECT
+
+
+def test_script_template_read_requires_auth(client):
+    res = client.get("/api/agents/script-templates/linux")
+    assert res.status_code in REJECT
+
+
+def test_script_template_write_enforces_agents_version_permission():
+    """Static guarantee: the write handler checks agents.version (not just authN).
+
+    A behavioral 403-for-viewer test would need a seeded DB + a minted viewer JWT;
+    instead we assert the permission gate is present in source, mirroring the
+    existing audit-style source tests. This is the core RCE fix (GHSA-7rhv).
+    """
+    src_path = os.path.join(os.path.dirname(__file__), "..", "routers", "agent.py")
+    with open(src_path, "r") as f:
+        src = f.read()
+    # Isolate the save_agent_script_template handler body.
+    m = re.search(r"async def save_agent_script_template\(.*?\n(.*?)\n@router\.", src, re.DOTALL)
+    assert m, "save_agent_script_template handler not found"
+    body = m.group(1)
+    assert 'check_user_permission' in body and '"agents", "version"' in body, (
+        "GHSA-7rhv regression: script-template WRITE no longer enforces the "
+        "agents.version permission — any JWT holder could poison the root install script"
+    )

--- a/backend/tests/test_ssrf_guard.py
+++ b/backend/tests/test_ssrf_guard.py
@@ -1,0 +1,68 @@
+"""Unit tests for the SSRF guard (GHSA-3vh4-gvxx-wm2p).
+
+The guard protects server-side fetches of ACME `directory_url` values. This
+project uses only public ACME CAs, so every non-public IP must be rejected.
+Tests avoid real network/DNS by using IP literals and scheme checks.
+"""
+import asyncio
+import pytest
+
+from utils.ssrf_guard import is_public_ip, assert_public_url, SSRFValidationError
+
+
+# ---- is_public_ip -----------------------------------------------------------
+
+@pytest.mark.parametrize("ip", [
+    "8.8.8.8", "1.1.1.1", "93.184.216.34",  # public
+])
+def test_public_ips_allowed(ip):
+    assert is_public_ip(ip) is True
+
+
+@pytest.mark.parametrize("ip", [
+    "127.0.0.1",            # loopback
+    "10.0.0.5",             # RFC1918
+    "172.19.0.1",           # RFC1918 (the SSRF PoC docker gateway)
+    "192.168.1.1",          # RFC1918
+    "169.254.169.254",      # link-local / cloud metadata
+    "0.0.0.0",              # unspecified
+    "::1",                  # IPv6 loopback
+    "fe80::1",              # IPv6 link-local
+    "::ffff:127.0.0.1",     # IPv4-mapped IPv6 loopback (R18c bypass)
+    "::ffff:169.254.169.254",  # IPv4-mapped metadata
+    "not-an-ip",            # garbage
+])
+def test_non_public_ips_rejected(ip):
+    assert is_public_ip(ip) is False
+
+
+# ---- assert_public_url ------------------------------------------------------
+
+def _raises(url):
+    with pytest.raises(SSRFValidationError):
+        asyncio.run(assert_public_url(url))
+
+
+def test_rejects_non_https_scheme():
+    # The SSRF PoC used http:// against an internal listener.
+    _raises("http://172.19.0.1:2121/internal-secret")
+    _raises("http://8.8.8.8/")            # even a public IP over http is refused
+    _raises("file:///etc/passwd")
+    _raises("gopher://8.8.8.8/")
+
+
+def test_rejects_private_ip_literals():
+    _raises("https://127.0.0.1/")
+    _raises("https://10.0.0.5/")
+    _raises("https://169.254.169.254/latest/meta-data/")
+    _raises("https://[::1]/")
+
+
+def test_rejects_empty_or_hostless():
+    _raises("")
+    _raises("https://")
+
+
+def test_allows_public_ip_literal_https():
+    # A public IP literal over https must pass (no DNS needed).
+    asyncio.run(assert_public_url("https://8.8.8.8/directory"))

--- a/backend/utils/ssrf_guard.py
+++ b/backend/utils/ssrf_guard.py
@@ -1,0 +1,116 @@
+"""
+SSRF guard for outbound HTTP fetches to user/DB-controlled URLs.
+
+GHSA-3vh4-gvxx-wm2p: the ACME `directory_url` was fetched server-side with no
+validation, turning the backend into a request-forwarding primitive against
+loopback / RFC1918 / link-local / cloud-metadata IP space (and reflecting the
+upstream JSON keys back to the caller).
+
+The classification logic mirrors the hardened ACME diagnostics probe
+(services/acme_diagnostics.py, R18b/R18c audits): unwrap IPv4-mapped IPv6, reject
+loopback/link-local/private/multicast/reserved/unspecified, resolve DNS off the
+event loop, and pin the aiohttp connector to IPv4 so the family the guard
+classifies equals the family the connector dials (no dual-stack AAAA bypass).
+
+Deployment note: this project uses ONLY public ACME CAs (e.g. Let's Encrypt), so
+every non-public IP is rejected — there is no internal/private-IP CA to allow.
+Residual: DNS rebinding between validate-time and fetch-time is not fully closed
+(fetching by hostname keeps TLS cert validation working); the IPv4 pin +
+https-only + admin-gating + internal-only exposure keep this residual low.
+"""
+import asyncio
+import ipaddress
+import socket
+from typing import List
+from urllib.parse import urlparse
+
+import aiohttp
+
+# Only https is legitimate for a public ACME directory URL.
+_ALLOWED_SCHEMES = {"https"}
+
+
+class SSRFValidationError(ValueError):
+    """Raised when a URL fails SSRF validation (bad scheme or non-public host)."""
+
+
+def is_public_ip(ip_str: str) -> bool:
+    """Return True only for globally-routable IPv4/IPv6 addresses.
+
+    Unwraps IPv4-mapped IPv6 (``::ffff:127.0.0.1``) before classification so an
+    attacker-controlled AAAA record cannot smuggle loopback/metadata through the
+    IPv6 checks.
+    """
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except (ValueError, TypeError):
+        return False
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    if ip.is_loopback or ip.is_link_local or ip.is_private:
+        return False
+    if ip.is_multicast or ip.is_reserved or ip.is_unspecified:
+        return False
+    return True
+
+
+async def _resolve_ips(host: str, *, timeout: float = 5.0) -> List[str]:
+    """Resolve `host` to IPv4 addresses without blocking the event loop."""
+    loop = asyncio.get_running_loop()
+    _, _, ips = await asyncio.wait_for(
+        loop.run_in_executor(None, socket.gethostbyname_ex, host),
+        timeout=timeout,
+    )
+    return ips or []
+
+
+async def assert_public_url(url: str, *, timeout: float = 5.0) -> None:
+    """Validate that `url` is safe to fetch server-side.
+
+    Requirements: https scheme, and a host that either is a public IP literal or
+    resolves entirely to public IPv4 addresses. Raises ``SSRFValidationError``
+    otherwise. Intended to be called immediately before the outbound request,
+    which MUST use ``safe_connector()`` and ``allow_redirects=False``.
+    """
+    if not url or not isinstance(url, str):
+        raise SSRFValidationError("A URL is required")
+    parsed = urlparse(url.strip())
+    if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
+        raise SSRFValidationError(f"URL scheme must be https (got '{parsed.scheme or 'none'}')")
+    host = parsed.hostname
+    if not host:
+        raise SSRFValidationError("URL has no host")
+
+    # Literal IP host: classify directly, no DNS needed.
+    try:
+        ipaddress.ip_address(host)
+        if not is_public_ip(host):
+            raise SSRFValidationError(f"URL host {host} is not a public IP address")
+        return
+    except ValueError:
+        pass  # hostname, not an IP literal -> resolve below
+
+    try:
+        ips = await _resolve_ips(host, timeout=timeout)
+    except asyncio.TimeoutError:
+        raise SSRFValidationError(f"DNS resolution timed out for {host}")
+    except Exception as e:  # socket.gaierror etc.
+        raise SSRFValidationError(f"DNS resolution failed for {host}: {e}")
+
+    if not ips:
+        raise SSRFValidationError(f"{host} did not resolve to any address")
+    if not all(is_public_ip(ip) for ip in ips):
+        raise SSRFValidationError(
+            f"{host} resolves to a non-public IP {ips} — refusing to fetch (SSRF guard)"
+        )
+
+
+def safe_connector() -> aiohttp.TCPConnector:
+    """IPv4-pinned aiohttp connector.
+
+    Forces the connect family to match what :func:`assert_public_url` classified
+    (closes the dual-stack AAAA bypass). TLS verification stays ON (default), so
+    the request must target the validated hostname. Always combine with
+    ``allow_redirects=False`` at the request call site.
+    """
+    return aiohttp.TCPConnector(family=socket.AF_INET)


### PR DESCRIPTION
Remediates three reported advisories, fixed entirely server-side. **No agent-script changes / no agent upgrade required.** This PR now contains **two commits** (initial remediation + post-review hardening).

## Commit 1 — initial remediation
- **GHSA-7rhv (CRITICAL RCE):** agent script-template POST/GET now require `agents.version`.
- **GHSA-3p5c (missing auth):** agent data-plane endpoints require a valid `X-API-Key` (checked before DB); operator/UI endpoints require a JWT; simple `/api/health` stays public.
- **GHSA-3vh4 (SSRF):** new `utils/ssrf_guard.py` (https + public-IP only, IPv4-pinned, no redirects) on settings test-connection, `acme_service.get_directory`/`_signed_request`, and Let's Encrypt account creation; test-connection no longer reflects arbitrary JSON keys.

## Commit 2 — post-review hardening (from a 3-agent + black-box audit of all 201 routes)
- **Regression fix:** `GET /api/agents` now accepts JWT **or** agent `X-API-Key` (agents poll it with their key; a JWT-only gate made them 401 → spurious HAProxy reload on restart).
- **Coverage gaps closed (same data class, now gated):** `/api/haproxy-cluster-pools/{id}/agents` (full inventory — bypassed the `/api/agents` lockdown), `/api/pools`, `/api/haproxy-cluster-pools`, `/api/dashboard/stats`, `/api/dashboard/overview`, `/api/haproxy/stats`, `/api/waf/rules`, `/api/health/errors`, `generate-uninstall-script`, and `POST /api/config/{validate,optimize,templates/*/generate}`.
- **SSRF gap:** `acme_service._get_nonce` (fetched `newNonce` from the directory JSON, unguarded, before the guarded POST) is now guarded.
- **Correctness:** 3 agent webhooks (config-applied/validation-failed/config-sync) no longer swallow their auth 401 into a 200.

## Verification
- Full `pytest tests/`: **1145 passed, 0 failed** (16 new regression tests).
- **Black-box audit of all 201 routes (unauthenticated):** no data leak and no unauthenticated mutation; every sensitive route returns 401/403. (A pre-existing group of read handlers wraps the 401 into a 500 via a broad `except` — no data exposed; left as-is/documented.)
- Live localtest stack smoke: agent-key `/api/agents`=200, anonymous=401, newly-gated endpoints reject anonymous & admit JWT.

Only `backend/**` changes; `backend/utils/agent_scripts/*` untouched.