### PR TITLE
chore(version): bump to 1.8.10 (security release)

### DIFF
--- a/backend/version.json
+++ b/backend/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.8.9",
-  "releaseName": "ACL -f pattern-file support (Issue #38 follow-up)",
-  "releaseDate": "2026-07-13"
+  "version": "1.8.10",
+  "releaseName": "Security hardening — RCE, missing-auth and SSRF advisories (GHSA-7rhv/3p5c/3vh4)",
+  "releaseDate": "2026-07-20"
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haproxy-openmanager-frontend",
-  "version": "1.8.9",
+  "version": "1.8.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haproxy-openmanager-frontend",
-      "version": "1.8.9",
+      "version": "1.8.10",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ant-design/icons": "^5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haproxy-openmanager-frontend",
-  "version": "1.8.9",
+  "version": "1.8.10",
   "description": "HAProxy Load Balancer Management UI",
   "license": "AGPL-3.0-or-later",
   "dependencies": {


### PR DESCRIPTION
Version bump to **1.8.10** for the security release that fixes GHSA-7rhv-c5pc-69r8 (RCE), GHSA-3p5c-m5m4-mjpx (missing auth), GHSA-3vh4-gvxx-wm2p (SSRF). Single-source `backend/version.json` + `frontend/package.json`/lock kept in sync.