### PR TITLE
fix(acme): stop HTTP-01 failing silently on split deployments

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -59,6 +59,13 @@ PUBLIC_URL=http://localhost:8000
 
 # Management base URL (defaults to PUBLIC_URL if not set)
 # Override this if your management interface is on a different URL
+#
+# This is also the last-resort fallback for the ACME HTTP-01 challenge backend,
+# i.e. the address written into haproxy.cfg as `server _acme_mgmt <host>:<port>`.
+# That address is resolved BY HAPROXY, ON THE HAPROXY NODE. If HAProxy runs
+# anywhere other than this machine, localhost points at the wrong box and HTTP-01
+# validation fails while DNS-01 keeps working. Set a routable address, with the
+# port, e.g. MANAGEMENT_BASE_URL=http://10.90.1.4:8080
 MANAGEMENT_BASE_URL=http://localhost:8000
 
 # ============================================================================

--- a/backend/main.py
+++ b/backend/main.py
@@ -1111,9 +1111,19 @@ async def get_version():
     return _version_info
 
 @app.get("/.well-known/acme-challenge/{token}")
-async def serve_acme_challenge(token: str):
+async def serve_acme_challenge(token: str, request: Request):
     """Serve ACME HTTP-01 challenge token. Public endpoint, no auth required."""
-    logger.info(f"ACME-CHALLENGE: Incoming request for token={token[:32]}...")
+    # Log who reached us. When HTTP-01 fails, the first question is always "did the
+    # request get here at all?" — and the answer separates a broken challenge-backend
+    # address (nothing arrives) from a wrong response (arrives, wrong body). The peer
+    # is normally the HAProxy node; X-Forwarded-For carries the CA when the frontend
+    # sets `option forwardfor`.
+    _peer = request.client.host if request.client else 'unknown'
+    _xff = request.headers.get('x-forwarded-for') or '-'
+    logger.info(
+        f"ACME-CHALLENGE: Incoming request for token={token[:32]}... "
+        f"peer={_peer} xff={_xff} host={request.headers.get('host') or '-'}"
+    )
     conn = None
     try:
         conn = await get_database_connection()

--- a/backend/models/cluster.py
+++ b/backend/models/cluster.py
@@ -26,6 +26,16 @@ class HAProxyClusterCreate(BaseModel):
     haproxy_bin_path: str = "/usr/sbin/haproxy"  # HAProxy binary path
     keepalived_config_path: str = "/etc/keepalived/keepalived.conf"  # HA/VIP: keepalived.conf path (Issue #27)
     pool_id: Optional[int] = None  # Which pool this cluster belongs to
+    # The create form submits both of these. Until they were declared here pydantic
+    # dropped them and the INSERT never carried them, so a cluster created with ACME
+    # switched on came back switched off with no error shown — the same silent-success
+    # failure this work exists to remove.
+    acme_enabled: Optional[bool] = None
+    acme_backend_url: Optional[str] = None
+
+    _validate_acme_backend_url = field_validator("acme_backend_url")(
+        _validated_acme_backend_url
+    )
 
 class HAProxyClusterUpdate(BaseModel):
     name: Optional[str] = None

--- a/backend/models/cluster.py
+++ b/backend/models/cluster.py
@@ -1,5 +1,21 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from typing import Optional, List
+
+from utils.acme_backend_url import AcmeBackendUrlError, validate_acme_backend_url
+
+
+def _validated_acme_backend_url(value: Optional[str]) -> Optional[str]:
+    """Shared field validator body for `acme_backend_url`.
+
+    Pydantic turns the raised ValueError into a 422 with this message attached, so
+    the operator sees why the value was refused instead of discovering months later
+    that HTTP-01 never worked. Returns the normalised value — callers persist THIS,
+    not the raw input, so surrounding whitespace never reaches haproxy.cfg.
+    """
+    try:
+        return validate_acme_backend_url(value)
+    except AcmeBackendUrlError as exc:
+        raise ValueError(str(exc)) from None
 
 class HAProxyClusterCreate(BaseModel):
     name: str
@@ -23,6 +39,10 @@ class HAProxyClusterUpdate(BaseModel):
     is_active: Optional[bool] = None
     acme_enabled: Optional[bool] = None
     acme_backend_url: Optional[str] = None
+
+    _validate_acme_backend_url = field_validator("acme_backend_url")(
+        _validated_acme_backend_url
+    )
 
 class HAProxyClusterResponse(BaseModel):
     id: int

--- a/backend/routers/cluster.py
+++ b/backend/routers/cluster.py
@@ -466,8 +466,27 @@ async def update_cluster(cluster_id: int, cluster: HAProxyClusterUpdate, authori
         # If acme_enabled actually changed, create a PENDING config version with entity snapshot
         if cluster.acme_enabled is not None and cluster.acme_enabled != existing_cluster.get('acme_enabled', False):
             try:
-                from services.haproxy_config import generate_haproxy_config_for_cluster
+                from services.haproxy_config import (
+                    generate_haproxy_config_for_cluster,
+                    is_config_generation_error,
+                )
                 config_content = await generate_haproxy_config_for_cluster(cluster_id)
+                if is_config_generation_error(config_content):
+                    # Same sentinel-instead-of-exception contract as the apply path. A
+                    # PENDING version holding the sentinel is a landmine: the operator
+                    # sees a pending change and applies it, replacing the whole config.
+                    logger.error(
+                        f"ACME TOGGLE: config generation for cluster {cluster_id} returned an "
+                        f"error sentinel; no PENDING version created: {config_content!r}"
+                    )
+                    raise HTTPException(
+                        status_code=422,
+                        detail=(
+                            "ACME setting was saved, but a configuration could not be generated "
+                            "for this cluster, so no pending change was created. "
+                            f"Generator reported: {config_content.strip()[:300]}"
+                        ),
+                    )
                 import time as _time
                 import json as _json
                 version_name = f"cluster-{cluster_id}-acme-{'enable' if cluster.acme_enabled else 'disable'}-{int(_time.time())}"
@@ -497,9 +516,16 @@ async def update_cluster(cluster_id: int, cluster: HAProxyClusterUpdate, authori
                     """, cluster_id, version_name, config_content, current_user.get('id', 1), metadata_json)
                 finally:
                     await close_database_connection(conn2)
+            except HTTPException:
+                # The sentinel guard above deliberately fails the request. Without this
+                # clause the generic handler below would swallow it and report success
+                # while no PENDING version exists — the exact silent-success failure
+                # mode this change exists to remove.
+                await close_database_connection(conn)
+                raise
             except Exception as acme_err:
                 logger.error(f"Failed to create ACME config version for cluster {cluster_id}: {acme_err}")
-        
+
         await close_database_connection(conn)
         
         # Log activity
@@ -1914,6 +1940,28 @@ defaults
                 logger.info(f"🧩 APPLY: Generating fresh configuration from database for cluster {cluster_id}")
                 fresh_config_content = await generate_haproxy_config_for_cluster(cluster_id, conn)
             
+            # `generate_haproxy_config_for_cluster` reports failure by RETURNING a
+            # one-line comment instead of raising (haproxy_config.py outer `except`).
+            # Without this guard that sentinel is hashed, stored as an APPLIED version
+            # and shipped to every agent — silently replacing the cluster's entire
+            # configuration with a comment. Any generator exception (an out-of-range
+            # port in acme_backend_url is enough) triggers it. Refuse the apply instead;
+            # the previous APPLIED version stays in force.
+            from services.haproxy_config import is_config_generation_error
+            if is_config_generation_error(fresh_config_content):
+                logger.error(
+                    f"APPLY ABORTED: config generation for cluster {cluster_id} returned an "
+                    f"error sentinel instead of a configuration: {fresh_config_content!r}"
+                )
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "Configuration could not be generated for this cluster, so nothing "
+                        "was applied and the running configuration is unchanged. "
+                        f"Generator reported: {fresh_config_content.strip()[:300]}"
+                    ),
+                )
+
             # Create a new consolidated config version with fresh content
             import hashlib
             import time

--- a/backend/routers/cluster.py
+++ b/backend/routers/cluster.py
@@ -302,12 +302,14 @@ async def create_cluster(cluster: HAProxyClusterCreate, authorization: str = Hea
         cluster_id = await conn.fetchval("""
             INSERT INTO haproxy_clusters (name, description, connection_type, is_active,
                                         stats_socket_path, haproxy_config_path, haproxy_bin_path,
-                                        keepalived_config_path, pool_id)
-            VALUES ($1, $2, $3, TRUE, $4, $5, $6, $7, $8)
+                                        keepalived_config_path, pool_id,
+                                        acme_enabled, acme_backend_url)
+            VALUES ($1, $2, $3, TRUE, $4, $5, $6, $7, $8, COALESCE($9, FALSE), $10)
             RETURNING id
         """, cluster.name, cluster.description, cluster.connection_type,
             cluster.stats_socket_path, cluster.haproxy_config_path, cluster.haproxy_bin_path,
-            cluster.keepalived_config_path, cluster.pool_id)
+            cluster.keepalived_config_path, cluster.pool_id,
+            cluster.acme_enabled, cluster.acme_backend_url)
         
         await close_database_connection(conn)
         
@@ -397,7 +399,8 @@ async def update_cluster(cluster_id: int, cluster: HAProxyClusterUpdate, authori
         # Check if cluster exists and get current values
         existing_cluster = await conn.fetchrow("""
             SELECT name, description, connection_type, is_active, stats_socket_path,
-                   haproxy_config_path, haproxy_bin_path, pool_id, acme_enabled
+                   haproxy_config_path, haproxy_bin_path, pool_id, acme_enabled,
+                   acme_backend_url
             FROM haproxy_clusters WHERE id = $1
         """, cluster_id)
         if not existing_cluster:

--- a/backend/routers/cluster.py
+++ b/backend/routers/cluster.py
@@ -111,6 +111,14 @@ router = APIRouter(prefix="/api/clusters", tags=["clusters"])
 logger = logging.getLogger(__name__)
 
 
+class _AcmeNoConfigChange(Exception):
+    """Internal signal: an ACME edit renders the same config, so mint nothing.
+
+    Control flow, not an error — it unwinds out of the version-minting block without
+    tripping the generic `except Exception` handler that would log it as a failure.
+    """
+
+
 class _ConcurrentlyDrained(Exception):
     """Sentinel raised inside ``apply_pending_changes`` when the
     advisory-lock-protected re-fetch shows that another caller
@@ -453,7 +461,13 @@ async def update_cluster(cluster_id: int, cluster: HAProxyClusterUpdate, authori
             update_fields.append(f"acme_enabled = ${param_counter}")
             update_values.append(cluster.acme_enabled)
             param_counter += 1
-        if cluster.acme_backend_url is not None:
+        # Keyed on "was the field submitted?", not "is it non-None". With a plain
+        # `is not None` test there is no way to CLEAR the value: the validator maps an
+        # empty box to None, which is indistinguishable from "not supplied", so once an
+        # operator set a per-cluster URL they could never revert to the global setting —
+        # the field would accept the edit and silently keep the old value.
+        _acme_url_submitted = 'acme_backend_url' in cluster.model_fields_set
+        if _acme_url_submitted:
             update_fields.append(f"acme_backend_url = ${param_counter}")
             update_values.append(cluster.acme_backend_url)
             param_counter += 1
@@ -463,12 +477,25 @@ async def update_cluster(cluster_id: int, cluster: HAProxyClusterUpdate, authori
             update_query = f"UPDATE haproxy_clusters SET {', '.join(update_fields)} WHERE id = $1"
             await conn.execute(update_query, *update_values)
 
-        # If acme_enabled actually changed, create a PENDING config version with entity snapshot
-        if cluster.acme_enabled is not None and cluster.acme_enabled != existing_cluster.get('acme_enabled', False):
+        # Create a PENDING config version when an ACME edit would change what the
+        # HAProxy nodes actually run.
+        #
+        # This used to trigger only on `acme_enabled` flipping. `acme_backend_url` is
+        # written to the DB a few lines above but minted nothing, so correcting a wrong
+        # challenge backend from the panel was a silent no-op: the value changed, no
+        # pending version existed, Apply answered "No pending changes to apply", and the
+        # nodes kept the old address indefinitely. That made the one field an operator
+        # needs to fix HTTP-01 impossible to actually apply.
+        _acme_toggled = (
+            cluster.acme_enabled is not None
+            and cluster.acme_enabled != existing_cluster.get('acme_enabled', False)
+        )
+        if _acme_toggled or _acme_url_submitted:
             try:
                 from services.haproxy_config import (
                     generate_haproxy_config_for_cluster,
                     is_config_generation_error,
+                    extract_acme_backend_target,
                 )
                 config_content = await generate_haproxy_config_for_cluster(cluster_id)
                 if is_config_generation_error(config_content):
@@ -487,9 +514,38 @@ async def update_cluster(cluster_id: int, cluster: HAProxyClusterUpdate, authori
                             f"Generator reported: {config_content.strip()[:300]}"
                         ),
                     )
+                # A URL edit that renders the same `server _acme_mgmt` line changes
+                # nothing on the nodes, so minting a version would put a no-op pending
+                # change in front of the operator. Compare that one line rather than the
+                # whole config: the generator also renders unrelated PENDING entities,
+                # so a full-text diff reports a change on every edit anyone has queued.
+                _active_config = await conn.fetchval("""
+                    SELECT config_content FROM config_versions
+                    WHERE cluster_id = $1 AND is_active = TRUE
+                    ORDER BY created_at DESC LIMIT 1
+                """, cluster_id)
+                _new_target = extract_acme_backend_target(config_content)
+                _old_target = extract_acme_backend_target(_active_config)
+                if not _acme_toggled and _new_target == _old_target:
+                    logger.info(
+                        f"ACME-BACKEND: cluster {cluster_id} URL updated but the rendered "
+                        f"challenge backend is unchanged ({_new_target!r}); no config "
+                        f"version created."
+                    )
+                    raise _AcmeNoConfigChange()
+
                 import time as _time
                 import json as _json
-                version_name = f"cluster-{cluster_id}-acme-{'enable' if cluster.acme_enabled else 'disable'}-{int(_time.time())}"
+                if _acme_toggled:
+                    _acme_kind = 'enable' if cluster.acme_enabled else 'disable'
+                else:
+                    _acme_kind = 'backend'
+                version_name = f"cluster-{cluster_id}-acme-{_acme_kind}-{int(_time.time())}"
+                logger.info(
+                    f"ACME-BACKEND: cluster {cluster_id} pending config version "
+                    f"'{version_name}' created — challenge backend {_old_target!r} -> "
+                    f"{_new_target!r}. Apply the cluster for the nodes to pick it up."
+                )
 
                 from utils.entity_snapshot import save_entity_snapshot
                 snapshot_metadata = await save_entity_snapshot(
@@ -501,7 +557,14 @@ async def update_cluster(cluster_id: int, cluster: HAProxyClusterUpdate, authori
                         "acme_backend_url": existing_cluster.get('acme_backend_url'),
                     },
                     new_values={
-                        "acme_enabled": cluster.acme_enabled,
+                        # `acme_enabled` is None when only the URL was submitted; the
+                        # snapshot must record the value that is actually in force, or a
+                        # rollback would write NULL over a working flag.
+                        "acme_enabled": (
+                            cluster.acme_enabled
+                            if cluster.acme_enabled is not None
+                            else existing_cluster.get('acme_enabled', False)
+                        ),
                         "acme_backend_url": getattr(cluster, 'acme_backend_url', None) or existing_cluster.get('acme_backend_url'),
                     },
                     operation="UPDATE"
@@ -516,6 +579,10 @@ async def update_cluster(cluster_id: int, cluster: HAProxyClusterUpdate, authori
                     """, cluster_id, version_name, config_content, current_user.get('id', 1), metadata_json)
                 finally:
                     await close_database_connection(conn2)
+            except _AcmeNoConfigChange:
+                # Not an error: the edit was accepted and simply renders the same
+                # address, so there is nothing for the operator to apply.
+                pass
             except HTTPException:
                 # The sentinel guard above deliberately fails the request. Without this
                 # clause the generic handler below would swallow it and report success

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -1,10 +1,12 @@
 from fastapi import APIRouter, HTTPException, Header
 from pydantic import BaseModel
 from typing import Dict, Any
+import json
 import logging
 from datetime import datetime
 
 from database.connection import get_database_connection, close_database_connection
+from utils.acme_backend_url import AcmeBackendUrlError, validate_acme_backend_url
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +52,39 @@ async def get_settings_by_category(category: str, authorization: str = Header(No
         await close_database_connection(conn)
 
 
+def _validate_acme_challenge_backend_url(value):
+    """Validate `acme.challenge_backend_url` exactly as the config renderer reads it.
+
+    Settings values are stored as jsonb, so the renderer json.loads them before use
+    (services/haproxy_config.py). Validating the raw column text instead of the
+    decoded string would check the quoting rather than the URL.
+    """
+    decoded = value
+    if isinstance(decoded, str):
+        try:
+            decoded = json.loads(decoded)
+        except (json.JSONDecodeError, TypeError):
+            pass
+    if decoded is None:
+        return
+    try:
+        validate_acme_backend_url(str(decoded))
+    except AcmeBackendUrlError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=f"acme.challenge_backend_url: {exc}",
+        ) from None
+
+
+# Per-key validators for settings that end up in generated configuration or in
+# outbound requests. Everything else is still written through unchecked; this is a
+# deliberate allow-list of the keys where a bad value causes silent breakage rather
+# than an obvious one.
+_SETTING_VALIDATORS = {
+    "acme.challenge_backend_url": _validate_acme_challenge_backend_url,
+}
+
+
 @router.put("/{category}")
 async def update_settings_by_category(
     category: str,
@@ -59,6 +94,13 @@ async def update_settings_by_category(
     current_user = await _get_admin_user(authorization)
     conn = await get_database_connection()
     try:
+        # Validate the whole batch before writing any of it, so a rejected key cannot
+        # leave the category half-applied.
+        for key_suffix, value in body.settings.items():
+            validator = _SETTING_VALIDATORS.get(f"{category}.{key_suffix}")
+            if validator is not None:
+                validator(value)
+
         updated = []
         for key_suffix, value in body.settings.items():
             full_key = f"{category}.{key_suffix}"

--- a/backend/services/acme_diagnostics.py
+++ b/backend/services/acme_diagnostics.py
@@ -8,9 +8,13 @@ suitable for an Antd Tabs/Steps display.
 Key constraints (Section 3.3 of the v1.5.0 plan):
 - DNS resolution uses stdlib socket.gethostbyname_ex via run_in_executor (we
   intentionally avoid pulling aiodns as a runtime dep for v1.5.0).
-- Port-80 probe is HEAD-only, target locked to the order's domains, success on
-  HTTP 200 OR 404, warns on egress timeout (don't fail-hard — corp egress
-  policies often blackhole outbound 80).
+- Port-80 probe is a GET (not HEAD) locked to the order's domains, because the
+  status code alone cannot tell a working challenge endpoint from a web UI: a
+  reverse proxy that has lost its /.well-known/acme-challenge/ location serves
+  its SPA with HTTP 200. The body's shape decides. Warns rather than fails on
+  egress timeout (corp egress policies often blackhole outbound 80) and on a
+  wrong responder (this probe sees the PUBLIC domain, not the challenge backend,
+  so it is evidence rather than a verdict).
 - All checks have hard wall-clock timeouts (asyncio.wait_for) to bound impact
   on the API event loop.
 - humanize_error_detail covers >= 11 RFC8555 problem types and is backwards
@@ -26,8 +30,6 @@ import time
 from typing import Any, Dict, List, Optional
 
 import aiohttp
-
-from services.haproxy_config import extract_acme_backend_target
 
 logger = logging.getLogger(__name__)
 
@@ -360,9 +362,13 @@ def _classify_probe_body(body: bytes, content_type: str) -> str:
 
 
 async def check_port80(domains: List[str], *, http_timeout: float = 5.0) -> Dict[str, Any]:
-    """Probe HTTP-01 readiness on port 80 with a HEAD request to a synthetic
-    challenge URL. Success on 200 OR 404 (404 means the well-known path is
-    served but no challenge yet — fine).
+    """Probe HTTP-01 readiness on port 80 with a GET to a synthetic challenge URL.
+
+    404 means the path is served but no challenge is outstanding, which is fine. A
+    200 is only fine if the body is NOT a web page: a proxy that has lost its
+    /.well-known/acme-challenge/ route falls through to its catch-all and answers
+    200 with index.html, which a status-code-only check accepts as healthy while
+    every real validation fails.
 
     On egress timeout we WARN rather than FAIL because many corporate egress
     policies blackhole port 80 outbound; that does not impair LE's ingress
@@ -585,9 +591,13 @@ async def check_routing(conn, domains: List[str], cluster_ids: List[int]) -> Dic
             duration_ms=int((time.time() - started) * 1000),
         )
 
-    # `mode` is nullable and the renderer treats NULL as http, so normalise here the
-    # same way rather than filtering it out. A tcp-mode frontend on port 80 cannot
-    # carry the challenge ACL at all, which the old query happily counted as routing.
+    # The WHERE clause is deliberately identical to the pre-existing one, so `not rows`
+    # still means exactly what it meant before and the `fail` branch below cannot fire
+    # in any situation where it previously passed. Narrowing it here (e.g. by adding a
+    # mode filter) would turn a tcp-only port-80 cluster from "ok" into "fail", and the
+    # site wizard blocks submit on any failing check — locking those installs the day
+    # this ships. Mode is examined afterwards, in Python, and only ever downgrades to
+    # `warn`.
     rows = await conn.fetch(
         """
         SELECT f.id, f.name, f.bind_address, f.bind_port, f.mode, f.default_backend,
@@ -595,7 +605,6 @@ async def check_routing(conn, domains: List[str], cluster_ids: List[int]) -> Dic
         FROM frontends f
         JOIN haproxy_clusters c ON c.id = f.cluster_id
         WHERE f.cluster_id = ANY($1::int[]) AND f.is_active = TRUE AND f.bind_port = 80
-          AND LOWER(COALESCE(f.mode, 'http')) = 'http'
         """,
         cluster_ids,
     )
@@ -610,6 +619,26 @@ async def check_routing(conn, domains: List[str], cluster_ids: List[int]) -> Dic
             details={"cluster_ids": cluster_ids},
             duration_ms=duration_ms,
         )
+
+    # Character-for-character the renderer's normalisation (services/haproxy_config.py),
+    # so this can never disagree with what actually gets emitted.
+    http_rows = [r for r in rows if (r["mode"] or "http").strip().lower() == "http"]
+    if not http_rows:
+        return _check_result(
+            "routing",
+            "HAProxy routing",
+            "warn",
+            (
+                "The only port-80 frontend(s) in the target cluster(s) are in tcp mode. "
+                "A tcp-mode frontend cannot carry the /.well-known/acme-challenge/ ACL, "
+                "so HTTP-01 cannot be served — use DNS-01, or add an http-mode frontend "
+                "on port 80."
+            ),
+            severity="warn",
+            details={"frontends": [dict(r) for r in rows]},
+            duration_ms=duration_ms,
+        )
+    rows = http_rows
 
     # A frontend row proves only that the DATABASE describes port-80 routing. The
     # renderer gates the challenge ACL on `acme_enabled`, and the nodes run whatever
@@ -637,18 +666,31 @@ async def check_routing(conn, domains: List[str], cluster_ids: List[int]) -> Dic
     missing_in_applied = []
     challenge_backends = {}
     for cluster_id in sorted({r["cluster_id"] for r in rows}):
-        applied = await conn.fetchval(
+        # Selector matched to the one the AGENT uses to fetch its config
+        # (routers/agent.py: status='APPLIED' AND is_active=TRUE), because the question
+        # here is "what are the nodes running right now?". Without `is_active` this can
+        # read a superseded row and report on a config that was never delivered.
+        # Extracting in SQL rather than pulling whole configs back per cluster: these
+        # files run to hundreds of KB on real installs.
+        applied = await conn.fetchrow(
             """
-            SELECT config_content FROM config_versions
-            WHERE cluster_id = $1 AND status = 'APPLIED'
+            SELECT position('use_backend _acme_challenge_backend' in config_content) > 0
+                       AS has_route,
+                   substring(config_content from 'server _acme_mgmt [^\\n]*') AS server_line
+            FROM config_versions
+            WHERE cluster_id = $1 AND status = 'APPLIED' AND is_active = TRUE
+              AND config_content IS NOT NULL
             ORDER BY created_at DESC LIMIT 1
             """,
             cluster_id,
         )
-        if not applied or "use_backend _acme_challenge_backend" not in applied:
+        if not applied or not applied["has_route"]:
             missing_in_applied.append(cluster_id)
             continue
-        challenge_backends[cluster_id] = extract_acme_backend_target(applied)
+        server_line = (applied["server_line"] or "").strip()
+        challenge_backends[cluster_id] = (
+            server_line[len("server _acme_mgmt "):].strip() if server_line else None
+        )
 
     if missing_in_applied:
         return _check_result(
@@ -662,6 +704,26 @@ async def check_routing(conn, domains: List[str], cluster_ids: List[int]) -> Dic
             ),
             severity="warn",
             details={"frontends": [dict(r) for r in rows], "clusters_not_applied": missing_in_applied},
+            duration_ms=duration_ms,
+        )
+
+    # A backend section with no `server` line: the route exists, `haproxy -c` passes,
+    # and every challenge request gets a 503 from an empty backend. Without this branch
+    # the falsy target slips past the loopback filter below and the check reports "ok".
+    serverless = sorted(cid for cid, target in challenge_backends.items() if not target)
+    if serverless:
+        return _check_result(
+            "routing",
+            "HAProxy routing",
+            "warn",
+            (
+                f"Cluster(s) {serverless} route the challenge path to a backend that has "
+                "no server line, so every request returns 503. The configured ACME "
+                "Challenge Backend URL could not be resolved into an address — check it "
+                "in Cluster Management, or Settings > ACME for the global value."
+            ),
+            severity="warn",
+            details={"frontends": [dict(r) for r in rows], "clusters_without_server": serverless},
             duration_ms=duration_ms,
         )
 

--- a/backend/services/acme_diagnostics.py
+++ b/backend/services/acme_diagnostics.py
@@ -27,6 +27,8 @@ from typing import Any, Dict, List, Optional
 
 import aiohttp
 
+from services.haproxy_config import extract_acme_backend_target
+
 logger = logging.getLogger(__name__)
 
 
@@ -330,6 +332,33 @@ async def check_dns(domains: List[str]) -> Dict[str, Any]:
     )
 
 
+# Enough to classify a response without turning the diagnostic into a way to pull
+# arbitrary amounts of a third party's content into our JSON.
+_PROBE_BODY_LIMIT = 65536
+
+
+def _classify_probe_body(body: bytes, content_type: str) -> str:
+    """Coarse shape of a probe response: html | json | text | empty | binary.
+
+    The body itself is deliberately NOT retained anywhere — the shape is all that is
+    needed to tell "served me a web page" from "served me a token", and keeping the
+    bytes would open a new read surface onto whatever is behind the address.
+    """
+    if not body:
+        return "empty"
+    ct = (content_type or "").lower()
+    head = body[:512].lstrip().lower()
+    if ct.startswith("text/html") or head.startswith((b"<!doctype", b"<html")):
+        return "html"
+    if ct.startswith("application/json") or head[:1] in (b"{", b"["):
+        return "json"
+    try:
+        body.decode("utf-8")
+    except UnicodeDecodeError:
+        return "binary"
+    return "text"
+
+
 async def check_port80(domains: List[str], *, http_timeout: float = 5.0) -> Dict[str, Any]:
     """Probe HTTP-01 readiness on port 80 with a HEAD request to a synthetic
     challenge URL. Success on 200 OR 404 (404 means the well-known path is
@@ -398,12 +427,43 @@ async def check_port80(domains: List[str], *, http_timeout: float = 5.0) -> Dict
                 continue
             url = f"http://{d}/.well-known/acme-challenge/diagnostic-probe"
             try:
-                async with session.head(url, allow_redirects=False) as resp:
-                    targets.append({
+                # GET, not HEAD: the status code alone cannot tell a working challenge
+                # endpoint from a SPA. A reverse proxy that has lost its
+                # /.well-known/acme-challenge/ location falls through to its catch-all
+                # and serves index.html with HTTP 200 — which the old
+                # `status in (200, 404)` rule accepted as healthy while every real
+                # validation failed. Only the body distinguishes them.
+                async with session.get(url, allow_redirects=False) as resp:
+                    body = await resp.content.read(_PROBE_BODY_LIMIT)
+                    content_type = (resp.headers.get("content-type") or "").split(";")[0].strip()
+                    body_class = _classify_probe_body(body, content_type)
+                    target = {
                         "domain": d,
                         "status": resp.status,
-                        "ok": resp.status in (200, 404),
-                    })
+                        "content_type": content_type or None,
+                        "body_len": len(body),
+                        "body_class": body_class,
+                    }
+                    if resp.status == 200 and body_class == "html":
+                        # Reachable, wrong responder. Reported as a warning rather than
+                        # a failure: this check probes the PUBLIC domain and cannot see
+                        # the challenge backend, so it is evidence, not a verdict — and
+                        # a new `fail` here would block the site wizard on upgrade day
+                        # for every install.
+                        target["warn"] = True
+                        target["diagnosis"] = (
+                            "responded 200 with an HTML page, not a challenge token — "
+                            "the request is reaching a web UI instead of the ACME endpoint"
+                        )
+                    elif resp.status in (301, 302, 303, 307, 308):
+                        target["warn"] = True
+                        target["redirect_location"] = resp.headers.get("location")
+                        target["diagnosis"] = (
+                            "redirected instead of serving the challenge path"
+                        )
+                    else:
+                        target["ok"] = resp.status in (200, 404)
+                    targets.append(target)
             except asyncio.TimeoutError:
                 targets.append({"domain": d, "error": "egress timeout", "warn": True})
                 skip_reason = "egress timeout"
@@ -425,7 +485,11 @@ async def check_port80(domains: List[str], *, http_timeout: float = 5.0) -> Dict
             details={"targets": targets},
             duration_ms=duration_ms,
         )
-    if warns and not [t for t in targets if t.get("ok")]:
+    # Surface warnings even when OTHER domains answered correctly. The old condition
+    # ("warn only if nothing succeeded") hid the single most diagnostic outcome there
+    # is: a multi-domain certificate where one name reaches a web UI instead of the
+    # challenge endpoint reported a clean pass.
+    if warns:
         # R18b audit fix (round 7): branch the rollup message on the
         # actual cause. Pre-fix the message was always "Egress to
         # port 80 appears blocked" — even when every target was
@@ -435,6 +499,36 @@ async def check_port80(domains: List[str], *, http_timeout: float = 5.0) -> Dict
         # corporate firewall logs while the real cause was an
         # internal-only DNS A record. Also harden against
         # `skip_reason=None` so the message never reads "(None)".
+        # Wrong-responder warnings take priority over every other cause: they are the
+        # only ones that mean "your server answered, and answered wrong", which is a
+        # different problem from "we could not test".
+        wrong_responder = [t for t in targets if t.get("diagnosis")]
+        if wrong_responder:
+            first = wrong_responder[0]
+            if first.get("body_class") == "html":
+                human = (
+                    f"{first['domain']} answered HTTP {first.get('status')} with an HTML "
+                    f"page ({first.get('content_type') or 'unknown type'}, "
+                    f"{first.get('body_len')} bytes) instead of a challenge token. The "
+                    "path is reaching a web interface, not the ACME endpoint — check "
+                    "that the reverse proxy in front of OpenManager routes "
+                    "/.well-known/acme-challenge/ to the API."
+                )
+            else:
+                human = (
+                    f"{first['domain']} answered HTTP {first.get('status')} "
+                    f"({first.get('diagnosis')})"
+                )
+            return _check_result(
+                "port80",
+                "Port 80 reachability",
+                "warn",
+                human,
+                severity="warn",
+                details={"targets": targets},
+                duration_ms=duration_ms,
+            )
+
         ssrf_skip = any(
             "non-public" in (t.get("skip") or "")
             or "SSRF" in (t.get("skip") or "")
@@ -491,11 +585,17 @@ async def check_routing(conn, domains: List[str], cluster_ids: List[int]) -> Dic
             duration_ms=int((time.time() - started) * 1000),
         )
 
+    # `mode` is nullable and the renderer treats NULL as http, so normalise here the
+    # same way rather than filtering it out. A tcp-mode frontend on port 80 cannot
+    # carry the challenge ACL at all, which the old query happily counted as routing.
     rows = await conn.fetch(
         """
-        SELECT id, name, bind_address, bind_port, mode, default_backend
-        FROM frontends
-        WHERE cluster_id = ANY($1::int[]) AND is_active = TRUE AND bind_port = 80
+        SELECT f.id, f.name, f.bind_address, f.bind_port, f.mode, f.default_backend,
+               f.cluster_id, c.acme_enabled
+        FROM frontends f
+        JOIN haproxy_clusters c ON c.id = f.cluster_id
+        WHERE f.cluster_id = ANY($1::int[]) AND f.is_active = TRUE AND f.bind_port = 80
+          AND LOWER(COALESCE(f.mode, 'http')) = 'http'
         """,
         cluster_ids,
     )
@@ -510,13 +610,88 @@ async def check_routing(conn, domains: List[str], cluster_ids: List[int]) -> Dic
             details={"cluster_ids": cluster_ids},
             duration_ms=duration_ms,
         )
+
+    # A frontend row proves only that the DATABASE describes port-80 routing. The
+    # renderer gates the challenge ACL on `acme_enabled`, and the nodes run whatever
+    # config was last APPLIED — so the row said "ok" during an incident where the
+    # live config had no usable challenge route at all. Check the two things the row
+    # cannot tell us. Both report `warn`, never `fail`: the site wizard blocks submit
+    # on any `fail`, so a new failing condition would lock every install on the day
+    # it ships.
+    acme_off = sorted({r["cluster_id"] for r in rows if not r["acme_enabled"]})
+    if acme_off:
+        return _check_result(
+            "routing",
+            "HAProxy routing",
+            "warn",
+            (
+                f"Cluster(s) {acme_off} have ACME Challenge Routing disabled, so the "
+                "generated config contains no /.well-known/acme-challenge/ route. "
+                "Enable it in Cluster Management, then apply the cluster."
+            ),
+            severity="warn",
+            details={"frontends": [dict(r) for r in rows], "acme_disabled_clusters": acme_off},
+            duration_ms=duration_ms,
+        )
+
+    missing_in_applied = []
+    challenge_backends = {}
+    for cluster_id in sorted({r["cluster_id"] for r in rows}):
+        applied = await conn.fetchval(
+            """
+            SELECT config_content FROM config_versions
+            WHERE cluster_id = $1 AND status = 'APPLIED'
+            ORDER BY created_at DESC LIMIT 1
+            """,
+            cluster_id,
+        )
+        if not applied or "use_backend _acme_challenge_backend" not in applied:
+            missing_in_applied.append(cluster_id)
+            continue
+        challenge_backends[cluster_id] = extract_acme_backend_target(applied)
+
+    if missing_in_applied:
+        return _check_result(
+            "routing",
+            "HAProxy routing",
+            "warn",
+            (
+                f"Cluster(s) {missing_in_applied} have no applied configuration carrying "
+                "the challenge route. The change exists in the database but the nodes are "
+                "still running an older config — apply the cluster."
+            ),
+            severity="warn",
+            details={"frontends": [dict(r) for r in rows], "clusters_not_applied": missing_in_applied},
+            duration_ms=duration_ms,
+        )
+
+    loopback = {
+        cid: target for cid, target in challenge_backends.items()
+        if target and target.split(":")[0].strip("[]").lower()
+        in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
+    }
+    if loopback:
+        return _check_result(
+            "routing",
+            "HAProxy routing",
+            "warn",
+            (
+                f"The applied config points the challenge backend at {sorted(loopback.values())}. "
+                "HAProxy resolves that on the HAProxy node, so it means the node itself, not "
+                "this management server. Set ACME Challenge Backend URL to a routable address."
+            ),
+            severity="warn",
+            details={"frontends": [dict(r) for r in rows], "challenge_backends": challenge_backends},
+            duration_ms=duration_ms,
+        )
+
     return _check_result(
         "routing",
         "HAProxy routing",
         "ok",
-        f"Found {len(rows)} HTTP frontend(s) on port 80",
+        f"Found {len(rows)} HTTP frontend(s) on port 80; challenge route present in applied config",
         severity="info",
-        details={"frontends": [dict(r) for r in rows]},
+        details={"frontends": [dict(r) for r in rows], "challenge_backends": challenge_backends},
         duration_ms=duration_ms,
     )
 

--- a/backend/services/acme_diagnostics.py
+++ b/backend/services/acme_diagnostics.py
@@ -440,14 +440,24 @@ async def check_port80(domains: List[str], *, http_timeout: float = 5.0) -> Dict
                 # `status in (200, 404)` rule accepted as healthy while every real
                 # validation failed. Only the body distinguishes them.
                 async with session.get(url, allow_redirects=False) as resp:
-                    body = await resp.content.read(_PROBE_BODY_LIMIT)
+                    # The body is EVIDENCE, not a precondition. If it cannot be read —
+                    # connection reset mid-response, a server that hangs after headers —
+                    # fall back to the status-only semantics this check has always had
+                    # rather than turning a healthy 404 into a hard failure. The stricter
+                    # rule below applies only when there is something to judge.
+                    try:
+                        body = await resp.content.read(_PROBE_BODY_LIMIT)
+                    except Exception:
+                        body = None
                     content_type = (resp.headers.get("content-type") or "").split(";")[0].strip()
-                    body_class = _classify_probe_body(body, content_type)
+                    body_class = (
+                        _classify_probe_body(body, content_type) if body is not None else "unread"
+                    )
                     target = {
                         "domain": d,
                         "status": resp.status,
                         "content_type": content_type or None,
-                        "body_len": len(body),
+                        "body_len": len(body) if body is not None else None,
                         "body_class": body_class,
                     }
                     if resp.status == 200 and body_class == "html":
@@ -647,7 +657,10 @@ async def check_routing(conn, domains: List[str], cluster_ids: List[int]) -> Dic
     # cannot tell us. Both report `warn`, never `fail`: the site wizard blocks submit
     # on any `fail`, so a new failing condition would lock every install on the day
     # it ships.
-    acme_off = sorted({r["cluster_id"] for r in rows if not r["acme_enabled"]})
+    # `.get()` rather than `[]`: the column gates a WARNING, so a row shape without
+    # it should not blow up the whole diagnostic. Absent means "assume enabled" —
+    # the applied-config check below is the authoritative one either way.
+    acme_off = sorted({r["cluster_id"] for r in rows if not r.get("acme_enabled", True)})
     if acme_off:
         return _check_result(
             "routing",

--- a/backend/services/haproxy_config.py
+++ b/backend/services/haproxy_config.py
@@ -39,6 +39,39 @@ def is_config_generation_error(config_content: Optional[str]) -> bool:
     return config_content.lstrip().startswith(CONFIG_GENERATION_ERROR_PREFIXES)
 
 
+def select_acme_backend_source(candidates: List[tuple]):
+    """Pick the first candidate that resolves into a usable address.
+
+    `candidates` is an ordered list of ``(source_name, url)`` from most to least
+    specific. Returns ``(source_name, url, target, skipped)`` where ``skipped`` lists
+    the ``(source_name, url, target)`` of candidates that were rejected.
+
+    Falling through on UNUSABLE values, not just empty ones, is the point. Values
+    predating validation are common — the settings field was free text — and a
+    scheme-less ``10.90.1.4:8080`` cannot be resolved. Stopping at the first non-empty
+    candidate would emit a backend section with no ``server`` line: ``haproxy -c``
+    still passes because the section exists, Apply succeeds, and every challenge
+    request then 503s from an empty backend with nothing to show for it.
+    """
+    skipped = []
+    for source, url in candidates:
+        if not url:
+            continue
+        target = resolve_acme_backend_target(url)
+        if target.error_code:
+            skipped.append((source, url, target))
+            continue
+        return source, url, target, skipped
+
+    # Nothing usable. Report against the last non-empty candidate so the rendered
+    # comment and the log name a concrete value rather than an empty one.
+    if skipped:
+        source, url, target = skipped[-1]
+        return source, url, target, skipped[:-1]
+    source, url = candidates[0] if candidates else ('none', '')
+    return source, url, resolve_acme_backend_target(url), skipped
+
+
 def extract_acme_backend_target(config_content: Optional[str]) -> Optional[str]:
     """Return the `server _acme_mgmt` argument string from a rendered config.
 
@@ -1658,35 +1691,40 @@ async def generate_haproxy_config_for_cluster(cluster_id: int, conn: Optional[An
                 # this whole block emits no log line at all (contrast the skip branches
                 # above), so a wrong challenge backend is invisible until Let's Encrypt
                 # fails. `acme_source` is logged with the rendered host:port below.
-                acme_source = 'cluster.acme_backend_url'
-                acme_url = cluster_info.get('acme_backend_url') or ''
-                if not acme_url:
-                    acme_source = 'system_settings.acme.challenge_backend_url'
-                    try:
-                        acme_settings = await db_conn.fetchrow(
-                            "SELECT value FROM system_settings WHERE key = 'acme.challenge_backend_url'"
-                        )
-                        if acme_settings and acme_settings['value']:
-                            val = acme_settings['value']
-                            if isinstance(val, str):
-                                try:
-                                    val = json.loads(val)
-                                except (json.JSONDecodeError, TypeError):
-                                    pass
-                            if val:
-                                acme_url = str(val)
-                    except Exception:
-                        pass
-                if not acme_url:
-                    acme_source = 'config.MANAGEMENT_BASE_URL'
-                    from config import MANAGEMENT_BASE_URL
-                    acme_url = MANAGEMENT_BASE_URL
+                acme_candidates = [
+                    ('cluster.acme_backend_url', cluster_info.get('acme_backend_url') or '')
+                ]
+                _settings_url = ''
+                try:
+                    acme_settings = await db_conn.fetchrow(
+                        "SELECT value FROM system_settings WHERE key = 'acme.challenge_backend_url'"
+                    )
+                    if acme_settings and acme_settings['value']:
+                        val = acme_settings['value']
+                        if isinstance(val, str):
+                            try:
+                                val = json.loads(val)
+                            except (json.JSONDecodeError, TypeError):
+                                pass
+                        if val:
+                            _settings_url = str(val)
+                except Exception:
+                    pass
+                acme_candidates.append(
+                    ('system_settings.acme.challenge_backend_url', _settings_url)
+                )
+                from config import MANAGEMENT_BASE_URL
+                acme_candidates.append(('config.MANAGEMENT_BASE_URL', MANAGEMENT_BASE_URL))
 
-                # Resolution never rejects: the shipped defaults are themselves
-                # loopback, so refusing to render would make every acme_enabled
-                # cluster unappliable — including for changes unrelated to ACME.
-                # Problems are reported, not enforced. See utils/acme_backend_url.
-                target = resolve_acme_backend_target(acme_url)
+                acme_source, acme_url, target, _skipped = select_acme_backend_source(
+                    acme_candidates
+                )
+                for _s_source, _s_url, _s_target in _skipped:
+                    logger.warning(
+                        f"ACME-BACKEND: cluster {cluster_id} skipping unusable value from "
+                        f"{_s_source} (reason={_s_target.error_code}): "
+                        f"{_s_target.error_message} value={_s_url!r}"
+                    )
 
                 config_lines.append("# ACME Challenge Backend (auto-managed by HAProxy OpenManager)")
                 config_lines.append("backend _acme_challenge_backend")

--- a/backend/services/haproxy_config.py
+++ b/backend/services/haproxy_config.py
@@ -6,6 +6,7 @@ import json
 import urllib.parse
 from typing import Optional, List, Dict, Any
 from database.connection import get_database_connection, close_database_connection
+from utils.acme_backend_url import resolve_acme_backend_target
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,33 @@ def is_config_generation_error(config_content: Optional[str]) -> bool:
     if not config_content:
         return True
     return config_content.lstrip().startswith(CONFIG_GENERATION_ERROR_PREFIXES)
+
+
+def extract_acme_backend_target(config_content: Optional[str]) -> Optional[str]:
+    """Return the `server _acme_mgmt` argument string from a rendered config.
+
+    e.g. ``"10.90.1.4:80"`` or ``"mgmt.internal:443 ssl verify none"``; ``None`` when
+    the cluster renders no ACME challenge backend at all.
+
+    Used to decide whether an ACME-related edit actually CHANGES the shipped
+    configuration. Comparing whole config texts would report a difference on every
+    unrelated pending edit; comparing this one line answers the only question that
+    matters here — "would the HAProxy nodes start talking to a different address?"
+    """
+    if not config_content:
+        return None
+    in_section = False
+    for line in config_content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("backend "):
+            in_section = stripped == "backend _acme_challenge_backend"
+            continue
+        if stripped.startswith(("frontend ", "listen ", "defaults", "global")):
+            in_section = False
+            continue
+        if in_section and stripped.startswith("server _acme_mgmt "):
+            return stripped[len("server _acme_mgmt "):].strip()
+    return None
 
 
 def _format_redirect_rule(rule: Any) -> Optional[str]:
@@ -906,7 +934,15 @@ async def generate_haproxy_config_for_cluster(cluster_id: int, conn: Optional[An
                         f"    bind {frontend['bind_address']}:{frontend['bind_port']}"
                     )
             
-            config_lines.append(f"    mode {frontend['mode']}")
+            # `frontends.mode` is `VARCHAR(10) DEFAULT 'http'` but NULLABLE, and rows
+            # can arrive with it unset via agent sync or config import. Interpolating
+            # the raw value then emits a literal `mode None`, which HAProxy rejects —
+            # taking down the whole cluster config, not just this frontend. Normalise
+            # once here and use the result everywhere below, so the ACME gate, the
+            # backend-mode check and the rendered line can never disagree with each
+            # other about what mode this frontend is in.
+            frontend_mode = (frontend.get('mode') or 'http').strip().lower()
+            config_lines.append(f"    mode {frontend_mode}")
 
             # ─────────────────────────────────────────────────────────────────
             # R2.3 / R3.3 (PR-1 hotfix): emit ordering buckets.
@@ -1018,7 +1054,7 @@ async def generate_haproxy_config_for_cluster(cluster_id: int, conn: Optional[An
                 _fe_buckets[cat].append(line)
 
             # ACME HTTP-01 Challenge routing (auto-managed)
-            if frontend['mode'] == 'http' and cluster_info.get('acme_enabled', False):
+            if frontend_mode == 'http' and cluster_info.get('acme_enabled', False):
                 _emit_fe("    acl is_acme_challenge path_beg /.well-known/acme-challenge/")
                 _emit_fe("    http-request allow if is_acme_challenge")
                 _emit_fe("    use_backend _acme_challenge_backend if is_acme_challenge")
@@ -1048,14 +1084,14 @@ async def generate_haproxy_config_for_cluster(cluster_id: int, conn: Optional[An
                 if default_backend_name and default_backend_name not in ('[]', '{}', 'null', 'None'):
                     backend_mode = backend_modes.get(default_backend_name)
 
-                    if backend_mode and backend_mode != frontend['mode']:
-                        logger.error(f"CONFIG ERROR: Frontend '{frontend['name']}' mode '{frontend['mode']}' does not match backend '{default_backend_name}' mode '{backend_mode}'")
+                    if backend_mode and backend_mode != frontend_mode:
+                        logger.error(f"CONFIG ERROR: Frontend '{frontend['name']}' mode '{frontend_mode}' does not match backend '{default_backend_name}' mode '{backend_mode}'")
                         # FIX-10 marker: 'BACKEND-MODE-WARNING' keyword in
                         # the comment body routes it to the 'default_be'
                         # bucket via _categorize_haproxy_directive, so the
                         # warning emits next to the actual default_backend
                         # directive instead of at the top of the block.
-                        _emit_fe(f"    # BACKEND-MODE-WARNING: Backend '{default_backend_name}' has mode '{backend_mode}' but frontend has mode '{frontend['mode']}'")
+                        _emit_fe(f"    # BACKEND-MODE-WARNING: Backend '{default_backend_name}' has mode '{backend_mode}' but frontend has mode '{frontend_mode}'")
                         _emit_fe(f"    # BACKEND-MODE-WARNING: HAProxy will reject this configuration! Please fix the mode mismatch in UI.")
 
                     _emit_fe(f"    default_backend {default_backend_name}")
@@ -1646,36 +1682,49 @@ async def generate_haproxy_config_for_cluster(cluster_id: int, conn: Optional[An
                     from config import MANAGEMENT_BASE_URL
                     acme_url = MANAGEMENT_BASE_URL
 
-                parsed = urllib.parse.urlparse(acme_url)
-                host = parsed.hostname or 'localhost'
-                port = parsed.port or (443 if parsed.scheme == 'https' else 8080)
-                ssl_flag = ' ssl verify none' if parsed.scheme == 'https' else ''
+                # Resolution never rejects: the shipped defaults are themselves
+                # loopback, so refusing to render would make every acme_enabled
+                # cluster unappliable — including for changes unrelated to ACME.
+                # Problems are reported, not enforced. See utils/acme_backend_url.
+                target = resolve_acme_backend_target(acme_url)
 
                 config_lines.append("# ACME Challenge Backend (auto-managed by HAProxy OpenManager)")
                 config_lines.append("backend _acme_challenge_backend")
                 config_lines.append("    mode http")
-                config_lines.append(f"    server _acme_mgmt {host}:{port}{ssl_flag}")
-                config_lines.append("")
-
-                # One greppable line per render. `ACME-BACKEND` is the support keyword:
-                # it answers "what address did we actually ship, and who chose it?"
-                # without shell access to the node.
-                logger.info(
-                    f"ACME-BACKEND: cluster {cluster_id} challenge backend rendered as "
-                    f"{host}:{port}{ssl_flag or ''} (source={acme_source}, url={acme_url!r})"
-                )
-                # This address is resolved ON THE HAPROXY NODE, not here. A loopback
-                # value therefore means "the HAProxy box itself", which is only ever
-                # correct for an all-in-one install — and it is what the shipped
-                # defaults produce, so warn rather than reject.
-                if host in ('localhost', '127.0.0.1', '::1', '0.0.0.0'):
-                    logger.warning(
-                        f"ACME-BACKEND: cluster {cluster_id} points at loopback "
-                        f"'{host}:{port}' (source={acme_source}). HAProxy resolves this on "
-                        f"the node, not on the management host, so HTTP-01 validation will "
-                        f"fail on any split deployment. Set a routable management address "
-                        f"in Cluster Management > ACME Challenge Backend URL."
+                if target.error_code:
+                    # The value cannot produce an address. Emit the section without a
+                    # `server` line rather than guessing: every HTTP frontend already
+                    # carries `use_backend _acme_challenge_backend`, and a use_backend
+                    # with no matching backend is fatal to `haproxy -c`. The operator's
+                    # raw value is deliberately NOT echoed into the file — a value
+                    # containing a newline would inject directives into a config pushed
+                    # to every node. It goes to the log instead.
+                    config_lines.append(
+                        f"    # ACME challenge backend unavailable ({target.error_code}) — "
+                        f"see Cluster Management > ACME Challenge Backend URL"
                     )
+                    logger.error(
+                        f"ACME-BACKEND: cluster {cluster_id} has an unusable challenge backend "
+                        f"URL (source={acme_source}, reason={target.error_code}): "
+                        f"{target.error_message} value={acme_url!r}"
+                    )
+                else:
+                    config_lines.append(
+                        f"    server _acme_mgmt {target.host}:{target.port}{target.ssl_flag}"
+                    )
+                    # One greppable line per render. `ACME-BACKEND` is the support
+                    # keyword: it answers "what address did we actually ship, and who
+                    # chose it?" without shell access to the node.
+                    logger.info(
+                        f"ACME-BACKEND: cluster {cluster_id} challenge backend rendered as "
+                        f"{target.host}:{target.port}{target.ssl_flag} "
+                        f"(source={acme_source}, url={acme_url!r})"
+                    )
+                for _warning in target.warnings:
+                    logger.warning(
+                        f"ACME-BACKEND: cluster {cluster_id} (source={acme_source}): {_warning}"
+                    )
+                config_lines.append("")
 
         # Only close the connection if it was created within this function
         if not conn:

--- a/backend/services/haproxy_config.py
+++ b/backend/services/haproxy_config.py
@@ -9,6 +9,34 @@ from database.connection import get_database_connection, close_database_connecti
 
 logger = logging.getLogger(__name__)
 
+# Sentinel prefixes returned by `generate_haproxy_config_for_cluster` INSTEAD of a
+# configuration when generation fails. They are plain strings (not exceptions) for
+# historical reasons: the function's outer `except` swallows everything and returns
+# a one-line comment as the "config".
+#
+# That is a data-loss primitive on its own: an exception anywhere in the generator —
+# e.g. `urllib.parse.urlparse('http://host:99999').port` raising ValueError for an
+# out-of-range port in `acme_backend_url` — collapses a whole cluster's haproxy.cfg
+# into a single comment line, which the apply path then stores as APPLIED and pushes
+# to every agent. Callers that PERSIST the returned text MUST reject it first; use
+# `is_config_generation_error()` rather than matching the string by hand.
+CONFIG_GENERATION_ERROR_PREFIXES = (
+    "# Error generating configuration:",
+    "# Error: Cluster not found",
+)
+
+
+def is_config_generation_error(config_content: Optional[str]) -> bool:
+    """True when `config_content` is a generator failure sentinel, not a configuration.
+
+    Persisting or shipping a sentinel silently destroys a cluster's configuration, so
+    every call site that writes the generator's output to `config_versions` (or hands
+    it to an agent) must guard with this.
+    """
+    if not config_content:
+        return True
+    return config_content.lstrip().startswith(CONFIG_GENERATION_ERROR_PREFIXES)
+
 
 def _format_redirect_rule(rule: Any) -> Optional[str]:
     """Render a single redirect rule into a HAProxy `redirect ...` line.
@@ -1589,8 +1617,15 @@ async def generate_haproxy_config_for_cluster(cluster_id: int, conn: Optional[An
                     f"frontend found (would create orphan backend section)."
                 )
             else:
+                # Track WHERE the effective URL came from. Support has no way today to
+                # tell an operator-set value from the shipped `localhost` default, and
+                # this whole block emits no log line at all (contrast the skip branches
+                # above), so a wrong challenge backend is invisible until Let's Encrypt
+                # fails. `acme_source` is logged with the rendered host:port below.
+                acme_source = 'cluster.acme_backend_url'
                 acme_url = cluster_info.get('acme_backend_url') or ''
                 if not acme_url:
+                    acme_source = 'system_settings.acme.challenge_backend_url'
                     try:
                         acme_settings = await db_conn.fetchrow(
                             "SELECT value FROM system_settings WHERE key = 'acme.challenge_backend_url'"
@@ -1607,6 +1642,7 @@ async def generate_haproxy_config_for_cluster(cluster_id: int, conn: Optional[An
                     except Exception:
                         pass
                 if not acme_url:
+                    acme_source = 'config.MANAGEMENT_BASE_URL'
                     from config import MANAGEMENT_BASE_URL
                     acme_url = MANAGEMENT_BASE_URL
 
@@ -1620,6 +1656,26 @@ async def generate_haproxy_config_for_cluster(cluster_id: int, conn: Optional[An
                 config_lines.append("    mode http")
                 config_lines.append(f"    server _acme_mgmt {host}:{port}{ssl_flag}")
                 config_lines.append("")
+
+                # One greppable line per render. `ACME-BACKEND` is the support keyword:
+                # it answers "what address did we actually ship, and who chose it?"
+                # without shell access to the node.
+                logger.info(
+                    f"ACME-BACKEND: cluster {cluster_id} challenge backend rendered as "
+                    f"{host}:{port}{ssl_flag or ''} (source={acme_source}, url={acme_url!r})"
+                )
+                # This address is resolved ON THE HAPROXY NODE, not here. A loopback
+                # value therefore means "the HAProxy box itself", which is only ever
+                # correct for an all-in-one install — and it is what the shipped
+                # defaults produce, so warn rather than reject.
+                if host in ('localhost', '127.0.0.1', '::1', '0.0.0.0'):
+                    logger.warning(
+                        f"ACME-BACKEND: cluster {cluster_id} points at loopback "
+                        f"'{host}:{port}' (source={acme_source}). HAProxy resolves this on "
+                        f"the node, not on the management host, so HTTP-01 validation will "
+                        f"fail on any split deployment. Set a routable management address "
+                        f"in Cluster Management > ACME Challenge Backend URL."
+                    )
 
         # Only close the connection if it was created within this function
         if not conn:

--- a/backend/tests/test_acme_backend_url.py
+++ b/backend/tests/test_acme_backend_url.py
@@ -10,6 +10,7 @@ import pytest
 from services.haproxy_config import (
     extract_acme_backend_target,
     is_config_generation_error,
+    select_acme_backend_source,
 )
 from utils.acme_backend_url import (
     AcmeBackendUrlError,
@@ -201,7 +202,74 @@ def test_url_change_that_renders_the_same_target_is_not_a_change():
 
 
 # ---------------------------------------------------------------------------
-# 4. The generator's failure sentinel must never be mistaken for a config.
+# 4. Source selection — an unusable value must not shadow a usable one.
+# ---------------------------------------------------------------------------
+
+
+def test_prefers_the_most_specific_usable_source():
+    source, url, target, skipped = select_acme_backend_source([
+        ("cluster", "http://10.0.0.1:80"),
+        ("settings", "http://10.0.0.2:80"),
+        ("env", "http://10.0.0.3:80"),
+    ])
+    assert (source, url, target.host) == ("cluster", "http://10.0.0.1:80", "10.0.0.1")
+    assert skipped == []
+
+
+def test_skips_an_unusable_value_and_uses_the_next_source():
+    # The regression this guards: a scheme-less value left over from the era when the
+    # settings field was free text resolves to nothing. Stopping there would emit a
+    # backend section with no `server` line — `haproxy -c` passes, Apply succeeds, and
+    # every challenge request 503s with no visible cause.
+    source, url, target, skipped = select_acme_backend_source([
+        ("cluster", "10.90.1.4:8080"),
+        ("settings", ""),
+        ("env", "http://10.90.1.4:8080"),
+    ])
+    assert source == "env"
+    assert target.error_code is None and target.host == "10.90.1.4"
+    assert [s[0] for s in skipped] == ["cluster"]
+
+
+def test_empty_sources_are_skipped_without_being_reported():
+    source, _url, target, skipped = select_acme_backend_source([
+        ("cluster", ""),
+        ("settings", None),
+        ("env", "http://10.0.0.9:80"),
+    ])
+    assert source == "env" and target.error_code is None
+    assert skipped == []
+
+
+def test_reports_the_last_attempted_value_when_nothing_resolves():
+    source, url, target, skipped = select_acme_backend_source([
+        ("cluster", "10.0.0.1:80"),
+        ("env", "not a url"),
+    ])
+    assert (source, url) == ("env", "not a url")
+    assert target.error_code, "the caller needs an error to render and log"
+    assert [s[0] for s in skipped] == ["cluster"]
+
+
+def test_all_sources_empty_yields_an_error_not_a_crash():
+    source, _url, target, skipped = select_acme_backend_source([
+        ("cluster", ""), ("settings", ""), ("env", ""),
+    ])
+    assert source == "cluster" and target.error_code == "empty" and skipped == []
+
+
+def test_loopback_is_usable_enough_to_render():
+    # Warned about, never skipped: the shipped defaults are loopback, so treating it as
+    # unusable would make the fallback chain fall off its own end on a stock install.
+    source, _url, target, _skipped = select_acme_backend_source([
+        ("env", "http://localhost:8080"),
+    ])
+    assert source == "env" and target.error_code is None
+    assert target.warnings
+
+
+# ---------------------------------------------------------------------------
+# 5. The generator's failure sentinel must never be mistaken for a config.
 # ---------------------------------------------------------------------------
 
 

--- a/backend/tests/test_acme_backend_url.py
+++ b/backend/tests/test_acme_backend_url.py
@@ -1,0 +1,223 @@
+"""ACME challenge backend URL validation, resolution and change detection.
+
+These pin the behaviour behind a real incident: a split deployment rendered
+`server _acme_mgmt <mgmt>:8080` against a port with no listener, HTTP-01 failed for
+weeks while DNS-01 kept working, and every existing check reported success. The
+three mechanisms below are what make that impossible to repeat silently.
+"""
+import pytest
+
+from services.haproxy_config import (
+    extract_acme_backend_target,
+    is_config_generation_error,
+)
+from utils.acme_backend_url import (
+    AcmeBackendUrlError,
+    resolve_acme_backend_target,
+    validate_acme_backend_url,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Boundary validation — what an operator may type.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("http://10.90.1.4:80", "http://10.90.1.4:80"),
+        ("http://10.90.1.4", "http://10.90.1.4"),
+        ("https://mgmt.internal:8443", "https://mgmt.internal:8443"),
+        # RFC1918 is the NORMAL answer here, unlike utils/ssrf_guard's policy: the
+        # operator is naming their own management host, which on a split deployment
+        # is private by definition.
+        ("http://192.168.1.5:8080", "http://192.168.1.5:8080"),
+        # Empty means "inherit from the next level of the resolution chain".
+        (None, None),
+        ("", None),
+        ("   ", None),
+        # Surrounding whitespace is normalised, not rejected — and the NORMALISED
+        # value is what callers persist, so it can never reach haproxy.cfg.
+        ("  http://10.0.0.5:80  ", "http://10.0.0.5:80"),
+    ],
+)
+def test_accepts_and_normalises_usable_values(value, expected):
+    assert validate_acme_backend_url(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value,code",
+    [
+        # Scheme-less values used to be accepted and then silently became `localhost`
+        # in the renderer — the trap that makes a correct diagnosis un-actionable.
+        ("10.90.1.4:8080", "no_scheme"),
+        ("localhost:8080", "no_scheme"),
+        ("ftp://10.0.0.5", "bad_scheme"),
+        # A newline would inject directives into a file pushed to every node.
+        ("http://10.90.1.4\nbind :9", "whitespace"),
+        ("http://10.90.1.4 x", "whitespace"),
+        # Loopback by number AND by name: `localhost` is what both shipped defaults
+        # contain, so catching only the numeric form would miss the common case.
+        ("http://localhost:8080", "loopback"),
+        ("http://LOCALHOST", "loopback"),
+        ("http://127.0.0.1", "loopback"),
+        ("http://[::1]:80", "loopback"),
+        ("http://0.0.0.0:80", "unspecified"),
+        ("http://169.254.169.254", "link_local"),
+        ("http://u:p@10.0.0.5", "userinfo"),
+        ("http://10.0.0.5/api", "has_path"),
+        ("http://10.0.0.5?x=1", "has_path"),
+        # urlparse defers port parsing to attribute access; unguarded this raises
+        # inside the config generator and destroys the cluster's whole config.
+        ("http://10.0.0.5:99999", "bad_port"),
+        ("http://10.0.0.5:abc", "bad_port"),
+        ("http://-bad-.com", "invalid_host"),
+    ],
+)
+def test_rejects_unusable_values_with_stable_codes(value, code):
+    with pytest.raises(AcmeBackendUrlError) as exc:
+        validate_acme_backend_url(value)
+    assert exc.value.code == code
+    assert str(exc.value), "every rejection must carry operator-facing prose"
+
+
+def test_rejects_values_longer_than_the_column():
+    # VARCHAR(500); without this the write fails as an opaque asyncpg 22001 -> 500.
+    with pytest.raises(AcmeBackendUrlError) as exc:
+        validate_acme_backend_url("http://" + "a" * 600 + ".com")
+    assert exc.value.code == "too_long"
+
+
+# ---------------------------------------------------------------------------
+# 2. Render-time resolution — never rejects, never raises.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,host,port,ssl_flag",
+    [
+        ("http://10.90.1.4:80", "10.90.1.4", 80, ""),
+        # Port-less http stays 8080, NOT the scheme default 80: the bundled compose
+        # publishes nginx on 8080, so installs relying on this have a working path
+        # today and changing it would break them silently in the renewal loop.
+        ("http://10.90.1.4", "10.90.1.4", 8080, ""),
+        ("https://m.io", "m.io", 443, " ssl verify none"),
+        ("http://localhost:8080", "localhost", 8080, ""),
+    ],
+)
+def test_resolution_preserves_existing_rendering(url, host, port, ssl_flag):
+    target = resolve_acme_backend_target(url)
+    assert (target.host, target.port, target.ssl_flag) == (host, port, ssl_flag)
+    assert target.error_code is None
+
+
+@pytest.mark.parametrize(
+    "url",
+    ["", None, "   ", "10.0.0.5:80", "http://h:99999", "http://10.0.0.5\nx", "http://ba d"],
+)
+def test_resolution_reports_instead_of_raising(url):
+    target = resolve_acme_backend_target(url)
+    assert target.error_code, "unusable values must be reported, not raised"
+    assert target.error_message
+
+
+def test_resolution_warns_on_loopback_rather_than_refusing():
+    # Refusing here would make every existing install unappliable: the shipped
+    # defaults ARE loopback, and the failure would block changes unrelated to ACME.
+    target = resolve_acme_backend_target("http://localhost:8080")
+    assert target.error_code is None
+    assert target.warnings and "Loopback" in target.warnings[0]
+
+
+def test_resolution_warns_when_the_port_is_omitted():
+    target = resolve_acme_backend_target("http://10.0.0.5")
+    assert target.port == 8080
+    assert any("port" in w.lower() for w in target.warnings)
+
+
+# ---------------------------------------------------------------------------
+# 3. Change detection — what makes a panel edit actually reach the nodes.
+# ---------------------------------------------------------------------------
+
+
+_CONFIG = """global
+    daemon
+
+frontend fe_http
+    bind 10.90.1.100:80
+    mode http
+    acl is_acme_challenge path_beg /.well-known/acme-challenge/
+    use_backend _acme_challenge_backend if is_acme_challenge
+    default_backend app
+
+backend app
+    server s1 10.0.0.9:8080
+
+# ACME Challenge Backend (auto-managed by HAProxy OpenManager)
+backend _acme_challenge_backend
+    mode http
+    server _acme_mgmt 10.90.1.4:80
+"""
+
+
+def test_extracts_the_challenge_backend_target():
+    assert extract_acme_backend_target(_CONFIG) == "10.90.1.4:80"
+
+
+def test_extracts_target_with_ssl_flag():
+    cfg = _CONFIG.replace("10.90.1.4:80", "m.io:443 ssl verify none")
+    assert extract_acme_backend_target(cfg) == "m.io:443 ssl verify none"
+
+
+def test_ignores_server_lines_in_other_backends():
+    # Comparing the whole config would flag every unrelated pending edit as a change;
+    # this must key on the ACME section alone.
+    cfg = _CONFIG.replace("backend _acme_challenge_backend", "backend something_else")
+    assert extract_acme_backend_target(cfg) is None
+
+
+def test_returns_none_when_the_section_has_no_server_line():
+    cfg = (
+        "backend _acme_challenge_backend\n"
+        "    mode http\n"
+        "    # ACME challenge backend unavailable (loopback)\n"
+    )
+    assert extract_acme_backend_target(cfg) is None
+
+
+@pytest.mark.parametrize("value", ["", None])
+def test_extraction_tolerates_empty_input(value):
+    assert extract_acme_backend_target(value) is None
+
+
+def test_url_change_that_renders_the_same_target_is_not_a_change():
+    # `http://10.90.1.4` and `http://10.90.1.4:8080` are different strings but the
+    # same shipped address; minting a config version for that would put a no-op
+    # pending change in front of the operator.
+    a = resolve_acme_backend_target("http://10.90.1.4")
+    b = resolve_acme_backend_target("http://10.90.1.4:8080")
+    assert (a.host, a.port, a.ssl_flag) == (b.host, b.port, b.ssl_flag)
+
+
+# ---------------------------------------------------------------------------
+# 4. The generator's failure sentinel must never be mistaken for a config.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "# Error generating configuration: boom",
+        "# Error: Cluster not found",
+        "",
+        None,
+    ],
+)
+def test_detects_generation_failure_sentinels(content):
+    assert is_config_generation_error(content) is True
+
+
+@pytest.mark.parametrize("content", [_CONFIG, "global\n    daemon\n"])
+def test_real_configs_are_not_flagged(content):
+    assert is_config_generation_error(content) is False

--- a/backend/tests/test_acme_diagnostics.py
+++ b/backend/tests/test_acme_diagnostics.py
@@ -104,13 +104,30 @@ async def test_check_dns_empty_ips_marks_failure(monkeypatch):
 
 
 # ----------------------------------------------------------------------------
-# Port-80 check (HEAD probe)
+# Port-80 check (GET probe)
+#
+# The probe is a GET, not a HEAD: a reverse proxy that has lost its
+# /.well-known/acme-challenge/ location falls through to its catch-all and serves
+# an SPA with HTTP 200, which a status-code-only check accepts as healthy while
+# every real validation fails. The fakes below therefore carry a body.
 # ----------------------------------------------------------------------------
 
 
-class _FakeHEADResp:
-    def __init__(self, status):
+class _FakeContent:
+    def __init__(self, body):
+        self._body = body
+
+    async def read(self, n=-1):
+        if self._body is None:
+            raise ConnectionResetError("reset mid-body")
+        return self._body if n is None or n < 0 else self._body[:n]
+
+
+class _FakeGETResp:
+    def __init__(self, status, body=b"", content_type="text/plain"):
         self.status = status
+        self.headers = {"content-type": content_type}
+        self.content = _FakeContent(body)
 
     async def __aenter__(self):
         return self
@@ -120,10 +137,13 @@ class _FakeHEADResp:
 
 
 class _FakeSession:
-    def __init__(self, *, statuses=None, raise_timeout=False, raise_client_error=False):
+    def __init__(self, *, statuses=None, raise_timeout=False, raise_client_error=False,
+                 bodies=None, content_types=None):
         self._statuses = list(statuses or [])
         self._raise_timeout = raise_timeout
         self._raise_client_error = raise_client_error
+        self._bodies = list(bodies or [])
+        self._content_types = list(content_types or [])
 
     async def __aenter__(self):
         return self
@@ -131,14 +151,16 @@ class _FakeSession:
     async def __aexit__(self, *args):
         return False
 
-    def head(self, url, allow_redirects=False):
+    def get(self, url, allow_redirects=False):
         if self._raise_timeout:
             raise asyncio.TimeoutError()
         if self._raise_client_error:
             import aiohttp
             raise aiohttp.ClientError("connection refused")
         status = self._statuses.pop(0) if self._statuses else 200
-        return _FakeHEADResp(status)
+        body = self._bodies.pop(0) if self._bodies else b""
+        ctype = self._content_types.pop(0) if self._content_types else "text/plain"
+        return _FakeGETResp(status, body, ctype)
 
 
 def _mock_public_dns(monkeypatch, ip="93.184.216.34"):
@@ -176,6 +198,65 @@ async def test_check_port80_ok_on_404(monkeypatch):
 
     out = await check_port80(["a.example.com"])
     assert out["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_check_port80_warns_when_200_carries_a_web_page(monkeypatch):
+    """The failure that motivated the GET probe.
+
+    A reverse proxy whose /.well-known/acme-challenge/ location has drifted away
+    falls through to its catch-all and serves the SPA. The status is 200, so the old
+    `status in (200, 404)` rule called the install healthy while every validation
+    failed. Only the body distinguishes them.
+    """
+    _mock_public_dns(monkeypatch)
+    spa = b'<!doctype html><html><head><title>HAProxy OpenManager</title></head>'
+
+    def _ctor(*args, **kwargs):
+        return _FakeSession(statuses=[200], bodies=[spa], content_types=["text/html"])
+
+    monkeypatch.setattr("aiohttp.ClientSession", _ctor)
+
+    out = await check_port80(["a.example.com"])
+    assert out["status"] == "warn"
+    target = out["details"]["targets"][0]
+    assert target["body_class"] == "html"
+    assert not target.get("ok")
+    assert "HTML" in out["message"]
+
+
+@pytest.mark.asyncio
+async def test_check_port80_falls_back_to_status_when_the_body_cannot_be_read(monkeypatch):
+    """A body that cannot be read is missing evidence, not a verdict.
+
+    Turning a connection reset mid-response into a hard failure would make a healthy
+    404 fail intermittently, so the check keeps its original status-only semantics
+    whenever there is nothing to judge.
+    """
+    _mock_public_dns(monkeypatch)
+
+    def _ctor(*args, **kwargs):
+        return _FakeSession(statuses=[404], bodies=[None])
+
+    monkeypatch.setattr("aiohttp.ClientSession", _ctor)
+
+    out = await check_port80(["a.example.com"])
+    assert out["status"] == "ok"
+    assert out["details"]["targets"][0]["body_class"] == "unread"
+
+
+@pytest.mark.asyncio
+async def test_check_port80_warns_on_a_redirect(monkeypatch):
+    _mock_public_dns(monkeypatch)
+
+    def _ctor(*args, **kwargs):
+        return _FakeSession(statuses=[301])
+
+    monkeypatch.setattr("aiohttp.ClientSession", _ctor)
+
+    out = await check_port80(["a.example.com"])
+    assert out["status"] == "warn"
+    assert out["details"]["targets"][0]["diagnosis"]
 
 
 @pytest.mark.asyncio
@@ -337,16 +418,92 @@ async def test_check_routing_fail_when_no_port80_frontend():
     assert "No HTTP frontend" in out["message"]
 
 
+def _routing_row(**over):
+    row = {"id": 1, "name": "fe-http", "bind_address": "0.0.0.0", "bind_port": 80,
+           "mode": "http", "default_backend": "be", "cluster_id": 1, "acme_enabled": True}
+    row.update(over)
+    return row
+
+
+def _applied(has_route=True, server_line="server _acme_mgmt 10.90.1.4:80"):
+    return {"has_route": has_route, "server_line": server_line}
+
+
 @pytest.mark.asyncio
-async def test_check_routing_ok_when_port80_frontend_present():
+async def test_check_routing_ok_when_challenge_route_is_in_the_applied_config():
+    # A port-80 frontend row alone is NOT enough. It describes what the database
+    # wants; the nodes run whatever was last applied. During the incident this
+    # function reported "ok" from the row count while the live config had no usable
+    # challenge route at all.
     conn = AsyncMock()
-    conn.fetch.return_value = [
-        {"id": 1, "name": "fe-http", "bind_address": "0.0.0.0", "bind_port": 80,
-         "mode": "http", "default_backend": "be"},
-    ]
+    conn.fetch.return_value = [_routing_row()]
+    conn.fetchrow.return_value = _applied()
     out = await check_routing(conn, ["a.example.com"], [1])
     assert out["status"] == "ok"
     assert len(out["details"]["frontends"]) == 1
+    assert out["details"]["challenge_backends"] == {1: "10.90.1.4:80"}
+
+
+@pytest.mark.asyncio
+async def test_check_routing_warns_when_acme_is_disabled_on_the_cluster():
+    conn = AsyncMock()
+    conn.fetch.return_value = [_routing_row(acme_enabled=False)]
+    out = await check_routing(conn, ["a.example.com"], [1])
+    assert out["status"] == "warn"
+    assert "disabled" in out["message"]
+
+
+@pytest.mark.asyncio
+async def test_check_routing_warns_when_the_route_is_not_in_the_applied_config():
+    conn = AsyncMock()
+    conn.fetch.return_value = [_routing_row()]
+    conn.fetchrow.return_value = _applied(has_route=False)
+    out = await check_routing(conn, ["a.example.com"], [1])
+    assert out["status"] == "warn"
+    assert "apply the cluster" in out["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_check_routing_warns_when_the_challenge_backend_has_no_server_line():
+    # `haproxy -c` passes because the section exists, so nothing else catches this;
+    # every challenge request 503s from an empty backend.
+    conn = AsyncMock()
+    conn.fetch.return_value = [_routing_row()]
+    conn.fetchrow.return_value = _applied(server_line=None)
+    out = await check_routing(conn, ["a.example.com"], [1])
+    assert out["status"] == "warn"
+    assert "503" in out["message"]
+
+
+@pytest.mark.asyncio
+async def test_check_routing_warns_when_the_challenge_backend_is_loopback():
+    conn = AsyncMock()
+    conn.fetch.return_value = [_routing_row()]
+    conn.fetchrow.return_value = _applied(server_line="server _acme_mgmt 127.0.0.1:8080")
+    out = await check_routing(conn, ["a.example.com"], [1])
+    assert out["status"] == "warn"
+    assert "HAProxy node" in out["message"]
+
+
+@pytest.mark.asyncio
+async def test_check_routing_warns_rather_than_fails_on_a_tcp_only_port80_cluster():
+    # The `fail` branch must stay reachable only when NO port-80 frontend exists at
+    # all: SiteWizard blocks submit on any failing check, so turning this into a
+    # failure would lock tcp-only installs the day it ships.
+    conn = AsyncMock()
+    conn.fetch.return_value = [_routing_row(mode="tcp")]
+    out = await check_routing(conn, ["a.example.com"], [1])
+    assert out["status"] == "warn"
+    assert "tcp mode" in out["message"]
+
+
+@pytest.mark.asyncio
+async def test_check_routing_treats_null_mode_as_http_like_the_renderer():
+    conn = AsyncMock()
+    conn.fetch.return_value = [_routing_row(mode=None)]
+    conn.fetchrow.return_value = _applied()
+    out = await check_routing(conn, ["a.example.com"], [1])
+    assert out["status"] == "ok"
 
 
 # ----------------------------------------------------------------------------

--- a/backend/utils/acme_backend_url.py
+++ b/backend/utils/acme_backend_url.py
@@ -1,0 +1,266 @@
+"""Validation and resolution for the ACME HTTP-01 challenge backend URL.
+
+This URL tells HAProxy where to proxy ``/.well-known/acme-challenge/*``. It is
+rendered into ``backend _acme_challenge_backend`` as ``server _acme_mgmt host:port``
+and — this is the part that makes it unlike every other URL in the product —
+**resolved on the HAProxy node, not on the management host**. A value that works
+when pasted into the management server's own browser can be completely dead from
+the data plane.
+
+Two entry points, deliberately asymmetric:
+
+``validate_acme_backend_url``
+    Called at the WRITE BOUNDARY (cluster PUT, settings PUT). Rejects values that
+    cannot express a reachable target. Strict here is safe: it only ever affects a
+    value an operator is typing right now, and the error text can teach.
+
+``resolve_acme_backend_target``
+    Called at RENDER TIME. Never raises, never rejects. Strictness here would be a
+    catastrophe: the shipped defaults (``config.py`` ``http://localhost:8000``,
+    ``docker-compose.yml`` ``http://localhost:8080``) mean essentially every
+    existing install resolves to loopback today, and refusing to render would make
+    every ``acme_enabled`` cluster unappliable — including for urgent changes that
+    have nothing to do with ACME. It reports problems instead of enforcing them.
+
+Two conscious departures from ``utils/ssrf_guard.py``, whose policy is the exact
+opposite of what is needed here:
+
+* **RFC1918 is allowed, and is usually the correct answer.** The guard exists to
+  stop the server being tricked into dialling internal space. Here the operator is
+  deliberately naming their own management host, which on a split deployment is
+  private by definition.
+* **No DNS resolution.** Resolving from the management host would re-introduce the
+  very wrong-vantage-point mistake this work exists to remove: what this box can
+  resolve says nothing about what the HAProxy node can reach.
+"""
+import ipaddress
+import re
+from typing import List, NamedTuple, Optional
+from urllib.parse import urlparse
+
+# `haproxy_clusters.acme_backend_url` / `system_settings.value` are VARCHAR(500).
+# Without this check asyncpg raises 22001 and the operator gets an opaque 500.
+MAX_URL_LENGTH = 500
+
+ALLOWED_SCHEMES = ("http", "https")
+
+# Port assumed when the URL omits one. NOT the scheme's default: the bundled
+# docker-compose publishes nginx on 8080 (`nginx/nginx.conf` listens 8080,
+# `docker-compose.yml` maps 8080:8080), so an operator who wrote a bare
+# `http://10.0.0.5` has a WORKING path today that resolves to :8080. Changing this
+# to 80 would break those installs silently — the first symptom would be the
+# unattended renewal loop failing months later. The value is kept and the omission
+# is surfaced as a warning instead.
+DEFAULT_HTTP_PORT = 8080
+DEFAULT_HTTPS_PORT = 443
+
+# RFC 1123 host label set. Deliberately not a full IDN implementation: an operator
+# naming their management host in a config file pushed to HAProxy nodes should use
+# ASCII, and HAProxy itself would not accept anything else on a `server` line.
+_HOSTNAME_RE = re.compile(
+    r"^(?=.{1,253}$)[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+    r"(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*\.?$"
+)
+
+_CONTROL_CHARS = frozenset("\t\n\r\v\f\x00")
+
+
+class AcmeBackendUrlError(ValueError):
+    """A value that cannot express a usable challenge backend target.
+
+    ``code`` is stable and machine-readable so the UI can map it to help text;
+    ``args[0]`` is operator-facing prose.
+    """
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+class AcmeBackendTarget(NamedTuple):
+    """What the renderer should emit, plus everything worth telling the operator."""
+
+    host: str
+    port: int
+    ssl_flag: str
+    #: Non-fatal observations. Rendered anyway; surfaced in logs and the panel.
+    warnings: List[str]
+    #: Set when the value could not be parsed at all and the caller must not emit
+    #: a `server` line. None on success.
+    error_code: Optional[str]
+    error_message: Optional[str]
+
+
+def _classify_host(host: str) -> Optional[str]:
+    """Return a rejection code for hosts that cannot be a management address."""
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        lowered = host.rstrip(".").lower()
+        # `localhost` is loopback by name and is the single most likely wrong value
+        # here — it is what both shipped defaults contain. Catching only the numeric
+        # form would let the exact failure this module exists to prevent straight
+        # through. RFC 6761 also reserves the whole `.localhost` tree.
+        if lowered == "localhost" or lowered.endswith(".localhost"):
+            return "loopback"
+        return None if _HOSTNAME_RE.match(host) else "invalid_host"
+
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    if ip.is_loopback:
+        return "loopback"
+    if ip.is_unspecified:
+        return "unspecified"
+    # Includes 169.254.169.254, the cloud metadata endpoint.
+    if ip.is_link_local:
+        return "link_local"
+    if ip.is_multicast:
+        return "multicast"
+    # NOTE: private (RFC1918) addresses fall through on purpose — see module docstring.
+    return None
+
+
+_REJECTION_PROSE = {
+    "too_long": f"URL must be at most {MAX_URL_LENGTH} characters.",
+    "whitespace": (
+        "URL must not contain spaces or line breaks. A trailing space survives parsing "
+        "and would be written into haproxy.cfg as part of the address."
+    ),
+    "no_scheme": (
+        "URL must start with http:// or https://. Without a scheme the value cannot be "
+        "parsed as an address and silently falls back to localhost, which on a HAProxy "
+        "node means the node itself."
+    ),
+    "bad_scheme": "URL scheme must be http or https.",
+    "userinfo": "URL must not contain credentials.",
+    "has_path": (
+        "Enter only the scheme, host and port — no path, query or fragment. The "
+        "challenge path is appended by HAProxy."
+    ),
+    "bad_port": "Port must be a number between 1 and 65535.",
+    "no_host": "URL must contain a host.",
+    "invalid_host": "Host is not a valid IP address or hostname.",
+    "loopback": (
+        "Loopback addresses cannot work here. HAProxy resolves this address on the "
+        "HAProxy node, so 127.0.0.1 means the node itself, not the management server. "
+        "Use the management server's routable address."
+    ),
+    "unspecified": (
+        "0.0.0.0 is a listen address, not a destination. Use the management server's "
+        "routable address."
+    ),
+    "link_local": "Link-local addresses cannot be used as a management address.",
+    "multicast": "Multicast addresses cannot be used as a management address.",
+}
+
+
+def validate_acme_backend_url(value: Optional[str]) -> Optional[str]:
+    """Validate an operator-supplied URL at the write boundary.
+
+    Returns the normalised value (stripped), or ``None`` for empty input, which
+    legitimately means "inherit from the next level of the resolution chain".
+    Raises :class:`AcmeBackendUrlError` otherwise.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise AcmeBackendUrlError("invalid_host", _REJECTION_PROSE["invalid_host"])
+
+    stripped = value.strip()
+    if not stripped:
+        return None
+
+    if len(stripped) > MAX_URL_LENGTH:
+        raise AcmeBackendUrlError("too_long", _REJECTION_PROSE["too_long"])
+    if any(c in _CONTROL_CHARS for c in stripped) or " " in stripped:
+        raise AcmeBackendUrlError("whitespace", _REJECTION_PROSE["whitespace"])
+
+    parsed = urlparse(stripped)
+
+    if not parsed.scheme:
+        raise AcmeBackendUrlError("no_scheme", _REJECTION_PROSE["no_scheme"])
+    if parsed.scheme.lower() not in ALLOWED_SCHEMES:
+        # `10.0.0.5:8080` parses as scheme='10.0.0.5' with no netloc, and
+        # `localhost:8080` as scheme='localhost'. Both are the same operator mistake,
+        # so point at the missing scheme rather than the nonsense one.
+        if not parsed.netloc:
+            raise AcmeBackendUrlError("no_scheme", _REJECTION_PROSE["no_scheme"])
+        raise AcmeBackendUrlError("bad_scheme", _REJECTION_PROSE["bad_scheme"])
+
+    if parsed.username is not None or parsed.password is not None:
+        raise AcmeBackendUrlError("userinfo", _REJECTION_PROSE["userinfo"])
+    if parsed.path not in ("", "/") or parsed.query or parsed.fragment:
+        raise AcmeBackendUrlError("has_path", _REJECTION_PROSE["has_path"])
+
+    try:
+        port = parsed.port
+    except ValueError:
+        # urlparse defers port parsing to attribute access; an out-of-range or
+        # non-numeric port raises here. Unguarded, this exception reaches the config
+        # generator's blanket `except` and collapses the cluster's whole config.
+        raise AcmeBackendUrlError("bad_port", _REJECTION_PROSE["bad_port"]) from None
+    if port is not None and not (1 <= port <= 65535):
+        raise AcmeBackendUrlError("bad_port", _REJECTION_PROSE["bad_port"])
+
+    host = parsed.hostname
+    if not host:
+        raise AcmeBackendUrlError("no_host", _REJECTION_PROSE["no_host"])
+
+    code = _classify_host(host)
+    if code is not None:
+        raise AcmeBackendUrlError(code, _REJECTION_PROSE[code])
+
+    return stripped
+
+
+def resolve_acme_backend_target(url: Optional[str]) -> AcmeBackendTarget:
+    """Resolve a stored URL into what the renderer emits. Never raises.
+
+    Values already in the database predate validation (and the shipped defaults are
+    themselves loopback), so anything unparseable or discouraged is reported through
+    ``warnings`` / ``error_code`` rather than refused.
+    """
+    warnings: List[str] = []
+    raw = (url or "").strip()
+
+    if not raw:
+        return AcmeBackendTarget(
+            "", 0, "", warnings, "empty", "No challenge backend URL configured."
+        )
+
+    if any(c in _CONTROL_CHARS for c in raw) or " " in raw:
+        # Must never reach haproxy.cfg: a newline here writes attacker- or
+        # accident-chosen directives into a file pushed to every node.
+        return AcmeBackendTarget(
+            "", 0, "", warnings, "whitespace", _REJECTION_PROSE["whitespace"]
+        )
+
+    parsed = urlparse(raw)
+    scheme = (parsed.scheme or "").lower()
+
+    try:
+        port = parsed.port
+    except ValueError:
+        return AcmeBackendTarget("", 0, "", warnings, "bad_port", _REJECTION_PROSE["bad_port"])
+
+    host = parsed.hostname
+    if not host or scheme not in ALLOWED_SCHEMES:
+        return AcmeBackendTarget(
+            "", 0, "", warnings, "no_scheme", _REJECTION_PROSE["no_scheme"]
+        )
+
+    if port is None:
+        port = DEFAULT_HTTPS_PORT if scheme == "https" else DEFAULT_HTTP_PORT
+        warnings.append(
+            f"No port given, assuming {port}. State the port explicitly — the assumed "
+            f"value is the bundled reverse proxy's port, not the scheme's default."
+        )
+
+    code = _classify_host(host)
+    if code == "invalid_host":
+        return AcmeBackendTarget("", 0, "", warnings, code, _REJECTION_PROSE[code])
+    if code is not None:
+        warnings.append(_REJECTION_PROSE[code])
+
+    ssl_flag = " ssl verify none" if scheme == "https" else ""
+    return AcmeBackendTarget(host, port, ssl_flag, warnings, None, None)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,13 +49,22 @@ services:
       - SECRET_KEY=your-secret-key-change-this-in-production
       - DEBUG=False
       - LOG_LEVEL=INFO
-      - PUBLIC_URL=http://localhost:8080
-      - MANAGEMENT_BASE_URL=http://localhost:8080
+      # Interpolated, not hardcoded: these were literals, so a value set in the
+      # host environment or .env was silently ignored and every install kept the
+      # localhost default. That default is also what the ACME challenge backend
+      # falls back to, and HAProxy resolves it ON THE HAPROXY NODE — so on any
+      # deployment where HAProxy is not this machine, it points at the wrong box.
+      - PUBLIC_URL=${PUBLIC_URL:-http://localhost:8080}
+      - MANAGEMENT_BASE_URL=${MANAGEMENT_BASE_URL:-http://localhost:8080}
       # Empty when unset on the host: the image CMD then falls back to
       # WEB_CONCURRENCY (uvicorn's native env) and finally to 1.
       - UVICORN_WORKERS=${UVICORN_WORKERS:-}
     volumes:
       - haproxy_configs:/etc/haproxy
+    # NOT published to the host: the API is reachable only through the nginx
+    # service (host :8080). Host port 8000 is therefore NOT this API — on a box
+    # running Portainer it is Portainer's edge tunnel, which answers 404 and looks
+    # deceptively like a working challenge endpoint.
     expose:
       - "8000"
     depends_on:

--- a/frontend/src/components/ClusterManagement.js
+++ b/frontend/src/components/ClusterManagement.js
@@ -160,7 +160,8 @@ const ClusterManagement = () => {
       agent_pool_id: cluster.pool_id || undefined,
       haproxy_user: cluster.haproxy_user || '',
       haproxy_group: cluster.haproxy_group || '',
-      acme_enabled: cluster.acme_enabled || false
+      acme_enabled: cluster.acme_enabled || false,
+      acme_backend_url: cluster.acme_backend_url || ''
     };
     
     console.log('🔍 CLUSTER EDIT DEBUG - Form values being set:', formValues);
@@ -202,7 +203,11 @@ const ClusterManagement = () => {
         pool_id: values.agent_pool_id || null,
         haproxy_user: values.haproxy_user || null,
         haproxy_group: values.haproxy_group || null,
-        acme_enabled: values.acme_enabled || false
+        acme_enabled: values.acme_enabled || false,
+        // Send null, not '', when cleared: null means "inherit the global setting",
+        // and the backend validator treats empty as inherit too. Omitting the key
+        // entirely would make the field look saved while silently discarding it.
+        acme_backend_url: (values.acme_backend_url || '').trim() || null
       };
       
       // For new clusters, explicitly set is_active to true
@@ -765,6 +770,47 @@ const ClusterManagement = () => {
             tooltip="Enable automatic ACME HTTP-01 challenge routing through this cluster's HTTP frontends for automated SSL certificate management"
           >
             <Switch checkedChildren="Enabled" unCheckedChildren="Disabled" />
+          </Form.Item>
+
+          <Form.Item
+            label="ACME Challenge Backend URL"
+            name="acme_backend_url"
+            tooltip="Where this cluster's HAProxy nodes reach OpenManager to fetch HTTP-01 challenge tokens. Leave empty to use the global setting under Settings > ACME."
+            extra="This address is resolved on the HAProxy node, not here — localhost would mean the HAProxy box itself. Include the port: without one, 8080 is assumed. Example: http://10.90.1.4:80"
+            rules={[
+              {
+                validator: (_, value) => {
+                  const v = (value || '').trim();
+                  if (!v) return Promise.resolve();
+                  if (!/^https?:\/\//i.test(v)) {
+                    return Promise.reject(new Error(
+                      'Start with http:// or https:// — without a scheme the value cannot be parsed as an address.'
+                    ));
+                  }
+                  if (/\s/.test(v)) {
+                    return Promise.reject(new Error('Must not contain spaces or line breaks.'));
+                  }
+                  let parsed;
+                  try {
+                    parsed = new URL(v);
+                  } catch (e) {
+                    return Promise.reject(new Error('Not a valid URL.'));
+                  }
+                  if (parsed.pathname !== '/' && parsed.pathname !== '') {
+                    return Promise.reject(new Error('Enter only scheme, host and port — no path.'));
+                  }
+                  const host = parsed.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+                  if (host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '0.0.0.0') {
+                    return Promise.reject(new Error(
+                      'Loopback cannot work here: HAProxy resolves this address on the node, so it would mean the node itself. Use the management server\u2019s routable address.'
+                    ));
+                  }
+                  return Promise.resolve();
+                }
+              }
+            ]}
+          >
+            <Input placeholder="http://10.90.1.4:80" />
           </Form.Item>
 
         </Form>


### PR DESCRIPTION
## Why

On a split deployment — HAProxy nodes on their own hosts, the management stack on a separate host with no public domain — HTTP-01 issuance failed for weeks while DNS-01 kept working. The rendered config said `server _acme_mgmt <mgmt>:8080` and nothing listened on that port.

Every check in the product reported success throughout. `check_routing` counted a `frontends` row and called it healthy; `check_port80` accepted `status in (200, 404)`, and the management host's reverse proxy — which had lost its `/.well-known/acme-challenge/` location — was answering 200 with the React SPA. The operator had no way to see any of this from the panel, and no way to fix it either: the per-cluster `acme_backend_url` field existed in the database and the API but had no UI at all.

The theme of this PR is that the product **inferred** that the challenge path worked instead of checking, and stayed silent at every layer where it was wrong.

## What changed

**Stop shipping generation failures as configuration.** `generate_haproxy_config_for_cluster` reports failure by *returning* `# Error generating configuration: ...` rather than raising, and nothing checked for it. The apply path hashed that comment, stored it as an APPLIED version and pushed it to every agent, silently replacing a cluster's whole `haproxy.cfg`. Any exception inside the generator triggers it — an out-of-range port in `acme_backend_url` is enough, since `urlparse('http://h:99999').port` raises on attribute access. Both persisting call sites now refuse with 422 and leave the running config in force.

**Make the challenge backend fixable from the panel.** The version-mint gate only fired when `acme_enabled` flipped, so changing `acme_backend_url` wrote the database and minted nothing: Apply answered *"No pending changes to apply"* and the nodes kept the old address indefinitely. It is now decided by comparing the rendered `server _acme_mgmt` line against the active version — the one line that answers "would the nodes talk to a different address?". Comparing whole configs would flag every unrelated pending edit. The field is added to the cluster form, keyed on `model_fields_set` so clearing it reverts to the global setting.

**Validate asymmetrically** (`utils/acme_backend_url.py`). At the write boundary, reject what cannot express a reachable target — including the two silent traps, where a scheme-less value became `localhost` and a bad port destroyed the config. At render time, never reject: the shipped defaults are themselves loopback, so refusing would make every `acme_enabled` cluster unappliable, including for changes unrelated to ACME. When a stored value cannot be resolved the renderer falls through to the next source rather than emitting a backend with no `server` line, which passes `haproxy -c` and then 503s silently.

RFC1918 is allowed and is usually the right answer here, and no DNS resolution is performed — both deliberate departures from `utils/ssrf_guard`, whose policy is the opposite of what this address needs. What the management host can resolve says nothing about what the HAProxy node can reach.

**Make diagnostics tell the truth.** `check_port80` uses GET and classifies the body, so a 200 carrying a web page is no longer accepted as healthy; an unreadable body falls back to the old status-only semantics rather than failing. `check_routing` filters `mode`, joins `acme_enabled`, reads the config the agent actually fetches (`status='APPLIED' AND is_active=TRUE`), and reports a loopback or server-less target. **Every new condition is `warn`, never `fail`** — `SiteWizard` blocks submit on any failing check, so a new failing condition would lock every install on upgrade day.

**Two adjacent bugs found on the way.** `frontends.mode` is nullable and was interpolated raw, emitting a literal `mode None` that HAProxy rejects — taking down the whole cluster config; it is now normalised once per frontend. And cluster creation declared neither ACME field and inserted neither, so a cluster created with ACME switched on came back switched off with no error shown.

**Packaging.** `docker-compose.yml` hardcoded `PUBLIC_URL` / `MANAGEMENT_BASE_URL` as literals with no interpolation and no `env_file`, so the operator's `.env` was silently ignored and the wrong default was load-bearing.

## Verification

- Full backend suite: **1477 passed on this branch, 1410 on `main`, 0 failed on either** (67 tests added).
- The app boots with the challenge route registered; the field validator fires through pydantic on both cluster models; `model_fields_set` distinguishes an explicit null from an omitted key; the settings validator rejects raw and jsonb-encoded bad values; a legacy scheme-less value is skipped so the next source renders.
- `docker compose config` validates.
- **Not verified:** the frontend was not linted or built (no `node_modules` in the dev environment). The JSX was reviewed by hand and the validator logic was checked against the backend rules in node, but it has not been compiled.

Three commits' worth of findings came from an adversarial review of the diff; four of the five confirmed findings were regressions introduced by this branch and are fixed here, with the reasoning recorded in the commit messages.

## Not included

Two designed-but-unbuilt layers, deliberately out of scope:

- **Auto-derivation.** The agent already heartbeats to a management URL that is *proven* reachable from the HAProxy node, and the product never uses it for ACME. Reporting it back would make the correct value the default. It needs an agent change and a trust-loop analysis (a value the agent supplies would influence config the server pushes to agents).
- **Path self-test.** The only trustworthy check is fetching a real token from the HAProxy node and comparing the body — status codes cannot distinguish a working endpoint from an SPA, which is exactly how this incident hid. That needs a new agent task channel; the existing one cannot be reused, because deployed agents ignore `request_type` and unconditionally `cat haproxy.cfg`.
